### PR TITLE
chore: Make img link absolute

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 <h3 align="center">
-  <img src="img/unstructured_logo.png" height="200">
+  <img
+    src="https://raw.githubusercontent.com/Unstructured-IO/unstructured/main/img/unstructured_logo.png"
+    height="200"
+  >
+
 </h3>
 
 <h3 align="center">


### PR DESCRIPTION
Switched to an absolute link for the unstructured image, so that it shows up correctly on the PyPI project page.

#### Testing
Make sure the image shows up on the github page for this branch.