### PR TITLE
chore: store models on hf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.2.1
 
-* Update image link
+* Implement auto model downloading
 
 ## 0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.1
+
+* Update image link
+
 ## 0.2.0
 
 * Initial release of unstructured-inference

--- a/Makefile
+++ b/Makefile
@@ -63,11 +63,6 @@ docker-build:
 # Local #
 ########
 
-## download-models          downloads unstructured models (AWS credentials must be in environment variables)
-.PHONY: download-models
-download-models:
-	./scripts/dl-models.sh
-
 ## run-app-dev:             runs the FastAPI api with hot reloading
 .PHONY: run-app-dev
 run-app-dev:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,7 +39,6 @@ ENV PATH="/home/${NB_USER}/.local/bin:${PATH}"
 COPY requirements/dev.txt requirements-dev.txt
 COPY requirements/base.txt requirements-base.txt
 COPY unstructured_inference unstructured_inference
-COPY .models .models
 
 # NOTE(crag) - Cannot use an ARG in the dst= path (so it seems), hence no ${NB_USER}, ${NB_UID}
 RUN python3.8 -m pip install  --no-cache  -r requirements-base.txt \

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,3 +2,4 @@ fastapi
 layoutparser[layoutmodels,tesseract]
 python-multipart
 uvicorn
+huggingface-hub

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -35,7 +35,9 @@ fonttools==4.37.4
 h11==0.14.0
     # via uvicorn
 huggingface-hub==0.10.1
-    # via timm
+    # via
+    #   -r requirements/base.in
+    #   timm
 idna==3.4
     # via
     #   anyio

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,6 +6,10 @@
 #
 anyio==3.6.1
     # via jupyter-server
+appnope==0.1.3
+    # via
+    #   ipykernel
+    #   ipython
 argon2-cffi==21.3.0
     # via
     #   jupyter-server
@@ -43,6 +47,10 @@ fastjsonschema==2.16.2
     # via nbformat
 idna==3.4
     # via anyio
+importlib-metadata==5.2.0
+    # via nbconvert
+importlib-resources==5.10.1
+    # via jsonschema
 ipykernel==6.16.0
     # via
     #   ipywidgets
@@ -53,7 +61,7 @@ ipykernel==6.16.0
     #   qtconsole
 ipython==8.7.0
     # via
-    #   -r dev.in
+    #   -r requirements/dev.in
     #   ipykernel
     #   ipywidgets
     #   jupyter-console
@@ -75,7 +83,7 @@ jinja2==3.1.2
 jsonschema==4.16.0
     # via nbformat
 jupyter==1.0.0
-    # via -r dev.in
+    # via -r requirements/dev.in
 jupyter-client==7.4.2
     # via
     #   ipykernel
@@ -160,7 +168,9 @@ pexpect==4.8.0
 pickleshare==0.7.5
     # via ipython
 pip-tools==6.12.1
-    # via -r dev.in
+    # via -r requirements/dev.in
+pkgutil-resolve-name==1.3.10
+    # via jsonschema
 prometheus-client==0.15.0
     # via
     #   jupyter-server
@@ -227,6 +237,10 @@ terminado==0.16.0
     #   notebook
 tinycss2==1.2.1
     # via nbconvert
+tomli==2.0.1
+    # via
+    #   build
+    #   pep517
 tornado==6.2
     # via
     #   ipykernel
@@ -262,6 +276,10 @@ wheel==0.37.1
     # via pip-tools
 widgetsnbextension==4.0.3
     # via ipywidgets
+zipp==3.11.0
+    # via
+    #   importlib-metadata
+    #   importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,21 +7,21 @@
 attrs==22.1.0
     # via pytest
 black==22.12.0
-    # via -r test.in
+    # via -r requirements/test.in
 certifi==2022.9.24
     # via requests
 charset-normalizer==2.1.1
     # via requests
 click==8.1.3
     # via
-    #   -r test.in
+    #   -r requirements/test.in
     #   black
 coverage[toml]==6.5.0
     # via
-    #   -r test.in
+    #   -r requirements/test.in
     #   pytest-cov
 flake8==5.0.4
-    # via -r test.in
+    # via -r requirements/test.in
 idna==3.4
     # via
     #   requests
@@ -29,7 +29,7 @@ idna==3.4
 iniconfig==1.1.1
     # via pytest
 label-studio-sdk==0.0.15
-    # via -r test.in
+    # via -r requirements/test.in
 lxml==4.9.1
     # via label-studio-sdk
 mccabe==0.7.0
@@ -37,7 +37,7 @@ mccabe==0.7.0
 multidict==6.0.2
     # via yarl
 mypy==0.991
-    # via -r test.in
+    # via -r requirements/test.in
 mypy-extensions==0.4.3
     # via
     #   black
@@ -63,7 +63,7 @@ pyparsing==3.0.9
 pytest==7.1.3
     # via pytest-cov
 pytest-cov==4.0.0
-    # via -r test.in
+    # via -r requirements/test.in
 pyyaml==6.0
     # via vcrpy
 requests==2.28.1
@@ -71,15 +71,20 @@ requests==2.28.1
 six==1.16.0
     # via vcrpy
 tomli==2.0.1
-    # via pytest
+    # via
+    #   black
+    #   coverage
+    #   mypy
+    #   pytest
 typing-extensions==4.4.0
     # via
+    #   black
     #   mypy
     #   pydantic
 urllib3==1.26.12
     # via requests
 vcrpy==4.2.1
-    # via -r test.in
+    # via -r requirements/test.in
 wrapt==1.14.1
     # via vcrpy
 yarl==1.8.1

--- a/scripts/dl-models.sh
+++ b/scripts/dl-models.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -euo pipefail
-
-aws s3 cp s3://utic-dev-models/oer_checkbox/detectron2_oer_checkbox.json "${1:-.models}"/detectron2_oer_checkbox.json
-aws s3 cp s3://utic-dev-models/oer_checkbox/detectron2_finetuned_oer_checkbox.pth  "${1:-.models}"/detectron2_finetuned_oer_checkbox.pth

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -2,8 +2,6 @@
 
 set -euo pipefail
 
-./scripts/dl-models.sh
-
 DOCKER_BUILDKIT=1 docker buildx build --platform=linux/amd64 -f docker/Dockerfile \
   --progress plain \
   -t ml-inference-dev:latest .

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
         "layoutparser[layoutmodels,tesseract]",
         "python-multipart",
         "uvicorn",
+        "huggingface-hub",
     ],
     extras_require={},
 )

--- a/test_unstructured_inference/models/test_model.py
+++ b/test_unstructured_inference/models/test_model.py
@@ -11,6 +11,15 @@ class MockModel:
 
 def test_get_model(monkeypatch):
     monkeypatch.setattr(models, "load_model", lambda *args, **kwargs: MockModel(*args, **kwargs))
+    monkeypatch.setattr(
+        models,
+        "_get_model_loading_info",
+        lambda *args, **kwargs: (
+            "fake-binary-path",
+            "fake-config-path",
+            {0: "Unchecked", 1: "Checked"},
+        ),
+    )
     assert isinstance(models.get_model("checkbox"), MockModel)
 
 

--- a/test_unstructured_inference/test_api.py
+++ b/test_unstructured_inference/test_api.py
@@ -26,6 +26,7 @@ class MockModel:
 
 def test_layout_parsing_pdf_api(sample_pdf_content, tmpdir, monkeypatch):
     monkeypatch.setattr(models, "load_model", lambda *args, **kwargs: MockModel(*args, **kwargs))
+    monkeypatch.setattr(models, "hf_hub_download", lambda *args, **kwargs: "fake-path")
     monkeypatch.setattr(detectron2, "is_detectron2_available", lambda *args: True)
     monkeypatch.setattr(
         DocumentLayout, "from_file", lambda *args, **kwargs: DocumentLayout.from_pages([])

--- a/unstructured_inference/__init__.py
+++ b/unstructured_inference/__init__.py
@@ -1,4 +1,0 @@
-from pathlib import Path
-
-
-MODEL_LOCATION = Path(__file__).parent.parent / ".models"

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.2.0"  # pragma: no cover
+__version__ = "0.2.1"  # pragma: no cover

--- a/unstructured_inference/models/__init__.py
+++ b/unstructured_inference/models/__init__.py
@@ -1,16 +1,28 @@
-import os
+from typing import Tuple, Dict
+from huggingface_hub import hf_hub_download
 
-from unstructured_inference import MODEL_LOCATION
 from unstructured_inference.models.detectron2 import load_model, Detectron2LayoutModel
 
 
 def get_model(model: str) -> Detectron2LayoutModel:
-    if model == "checkbox":
-        model_path = os.path.join(MODEL_LOCATION, "detectron2_finetuned_oer_checkbox.pth")
-        config_path = os.path.join(MODEL_LOCATION, "detectron2_oer_checkbox.json")
-        label_map = {0: "Unchecked", 1: "Checked"}
-        detector = load_model(config_path=config_path, model_path=model_path, label_map=label_map)
-    else:
-        raise ValueError(f"Unknown model type: {model}")
+    """Gets the model object by model name."""
+    model_path, config_path, label_map = _get_model_loading_info(model)
+    detector = load_model(config_path=config_path, model_path=model_path, label_map=label_map)
 
     return detector
+
+
+def _get_model_loading_info(model: str) -> Tuple[str, str, Dict[int, str]]:
+    """Gets local model binary and config locations and label map, downloading if necessary."""
+    # TODO(alan): Find the right way to map model name to retrieval. It seems off that testing
+    # needs to mock hf_hub_download.
+    if model == "checkbox":
+        repo_id = "unstructuredio/oer-checkbox"
+        binary_fn = "detectron2_finetuned_oer_checkbox.pth"
+        config_fn = "detectron2_oer_checkbox.json"
+        model_path = hf_hub_download(repo_id, binary_fn)
+        config_path = hf_hub_download(repo_id, config_fn)
+        label_map = {0: "Unchecked", 1: "Checked"}
+    else:
+        raise ValueError(f"Unknown model type: {model}")
+    return model_path, config_path, label_map


### PR DESCRIPTION
Added code to download `oer-checkbox` model from a public [repo](https://huggingface.co/unstructuredio/oer-checkbox/) on huggingface. This should remove all dependencies on assets in private spaces and open the door for full use of this repo as a package.

Tested by building the container and deploying to a test EC2 instance.

#### Testing
```python
from unstructured_inference.models import get_model

get_model("checkbox")

```
Should show 2 downloading bars the first time you run this code, for the model binary and the model config.

Subsequent runs do not download anything (as long as the file is still present locally).