### PR TITLE
chore: logger should not be setting up a BasicConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 0.2.1
+## 0.2.1-dev0
 
+* Removes BasicConfig from logger configuration
 * Implement auto model downloading
 
 ## 0.2.0

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.2.1"  # pragma: no cover
+__version__ = "0.2.1-dev0"  # pragma: no cover

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -7,11 +7,9 @@ from layoutparser.models.detectron2.layoutmodel import Detectron2LayoutModel
 import numpy as np
 from PIL import Image
 
-from unstructured_inference.logger import get_logger
+from unstructured_inference.logger import logger
 import unstructured_inference.models.tesseract as tesseract
 import unstructured_inference.models.detectron2 as detectron2
-
-logger = get_logger()
 
 
 @dataclass

--- a/unstructured_inference/logger.py
+++ b/unstructured_inference/logger.py
@@ -1,15 +1,3 @@
 import logging
-import os
-from typing import Final
 
-DEFAULT_LOG_LEVEL: Final[str] = "WARNING"
-
-logging.basicConfig(format="%(asctime)s [%(levelname)s]: %(message)s")
-
-
-def get_logger() -> logging.Logger:
-    log_level = os.environ.get("LOG_LEVEL", DEFAULT_LOG_LEVEL).upper()
-    log_level = DEFAULT_LOG_LEVEL if not log_level else log_level
-    logger = logging.getLogger(__name__)
-    logger.setLevel(level=log_level)
-    return logger
+logger = logging.getLogger("unstructured_inference")

--- a/unstructured_inference/models/detectron2.py
+++ b/unstructured_inference/models/detectron2.py
@@ -7,9 +7,8 @@ from layoutparser.models.detectron2.layoutmodel import (
 )
 from layoutparser.models.model_config import LayoutModelConfig
 
-from unstructured_inference.logger import get_logger
+from unstructured_inference.logger import logger
 
-logger = get_logger()
 
 DETECTRON_CONFIG: Final = "lp://PubLayNet/faster_rcnn_R_50_FPN_3x/config"
 DEFAULT_LABEL_MAP: Final[Dict[int, str]] = {

--- a/unstructured_inference/models/tesseract.py
+++ b/unstructured_inference/models/tesseract.py
@@ -1,10 +1,8 @@
 from layoutparser.ocr.tesseract_agent import is_pytesseract_available, TesseractAgent
 
-from unstructured_inference.logger import get_logger
+from unstructured_inference.logger import logger
 
 ocr_agent: TesseractAgent = None
-
-logger = get_logger()
 
 
 def load_agent():


### PR DESCRIPTION
### Summary
Clean up loggers for `unstructured-inference` so it doesn't have BasicConfig, a logger named  `unstructured_inference` will be added to the [logger config file](https://github.com/Unstructured-IO/unstructured-infra-tools/blob/main/logger_config.yaml) in `unstructured-infra-tools`.

Related PR: https://github.com/Unstructured-IO/unstructured/pull/106