### PR TITLE
chore: remove detectron from setup.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.2.1-dev1
+## 0.2.1
 
 * Refactor to facilitate local inference
 * Removes BasicConfig from logger configuration

--- a/README.md
+++ b/README.md
@@ -17,12 +17,26 @@ These models are invoked via API as part of the partitioning bricks in the `unst
 
 ### Package
 
-Requires [`torch>=1.8`](https://pytorch.org/get-started/locally/). Once this is satisfied, run 
-`pip install unstructured-inference`.
+Run `pip install unstructured-inference`.
+
+### Detectron2
+
+[Detectron2](https://github.com/facebookresearch/detectron2) is required for most inference tasks 
+but is not automatically installed with this package. 
+For MacOS and Linux, build from source with:
+```shell
+pip install 'git+https://github.com/facebookresearch/detectron2.git@v0.4#egg=detectron2'
+```
+Other install options can be found in the 
+[Detectron2 installation guide](https://detectron2.readthedocs.io/en/latest/tutorials/install.html).
+
+Windows is not officially supported by Detectron2, but some users are able to install it anyway. 
+See discussion [here](https://layout-parser.github.io/tutorials/installation#for-windows-users) for 
+tips on installing Detectron2 on Windows.
 
 ### Repository
 
-Clone the repo and run `make install` to install dependencies.
+To install the repository for development, clone the repo and run `make install` to install dependencies.
 Run `make help` for a full list of install options.
 
 ## Getting Started

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,6 @@ setup(
     entry_points={},
     install_requires=[
         "fastapi",
-        "detectron2@git+https://github.com/facebookresearch/detectron2.git@v0.6#egg=detectron2",
         "layoutparser[layoutmodels,tesseract]",
         "python-multipart",
         "uvicorn",

--- a/setup.py
+++ b/setup.py
@@ -21,14 +21,6 @@ from setuptools import setup, find_packages
 
 from unstructured_inference.__version__ import __version__
 
-try:
-    import torch
-
-    torch_ver = [int(x) for x in torch.__version__.split(".")[:2]]
-    assert torch_ver >= [1, 8]
-except (ImportError, AssertionError) as e:
-    raise Exception("Requires PyTorch >= 1.8") from e
-
 setup(
     name="unstructured_inference",
     description="A library for performing inference using trained models.",

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.2.1-dev1"  # pragma: no cover
+__version__ = "0.2.1"  # pragma: no cover


### PR DESCRIPTION
Having a non-pip dependency prevents `unstructured-inference` from being installed as a package from pypi, so this PR removes detectron2 from the `setup.py` dependencies. Also removed the code to fail the install if `torch` isn't installed - `torch` will be installed with `layoutparser`, and will be present when the user builds Detectron2 from source.

Instructions have been updated to reflect the changes.