### PR TITLE
chore: cut release for image processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.2.2-dev1
+## 0.2.2
 
 * Add capability to process image files
 * Add logic to use OCR when layout text is full of unknown characters

--- a/test_unstructured_inference/test_api.py
+++ b/test_unstructured_inference/test_api.py
@@ -9,15 +9,6 @@ from unstructured_inference.inference.layout import DocumentLayout
 import unstructured_inference.models.detectron2 as detectron2
 
 
-@pytest.fixture
-def sample_pdf_content():
-    return """
-    this is the content of a sample pdf file.
-    Title: ...
-    Author: ...
-    """
-
-
 class MockModel:
     def __init__(self, *args, **kwargs):
         self.args = args

--- a/test_unstructured_inference/test_api.py
+++ b/test_unstructured_inference/test_api.py
@@ -2,7 +2,6 @@ import pytest
 import os
 
 from fastapi.testclient import TestClient
-from fastapi import HTTPException
 
 from unstructured_inference.api import app
 from unstructured_inference import models
@@ -51,7 +50,7 @@ def test_layout_parsing_api(monkeypatch, filetype, ext):
 
 def test_bad_route_404():
     client = TestClient(app)
-    filename = os.path.join("sample-docs", f"loremipsum.pdf")
+    filename = os.path.join("sample-docs", "loremipsum.pdf")
     response = client.post("/layout/badroute", files={"file": (filename, open(filename, "rb"))})
     assert response.status_code == 404
 

--- a/test_unstructured_inference/test_api.py
+++ b/test_unstructured_inference/test_api.py
@@ -2,6 +2,7 @@ import pytest
 import os
 
 from fastapi.testclient import TestClient
+from fastapi import HTTPException
 
 from unstructured_inference.api import app
 from unstructured_inference import models
@@ -46,6 +47,13 @@ def test_layout_parsing_api(monkeypatch, filetype, ext):
         data={"model": "fake_model"},
     )
     assert response.status_code == 422
+
+
+def test_bad_route_404():
+    client = TestClient(app)
+    filename = os.path.join("sample-docs", f"loremipsum.pdf")
+    response = client.post("/layout/badroute", files={"file": (filename, open(filename, "rb"))})
+    assert response.status_code == 404
 
 
 def test_healthcheck(monkeypatch):

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.2.2-dev1"  # pragma: no cover
+__version__ = "0.2.2"  # pragma: no cover

--- a/unstructured_inference/api.py
+++ b/unstructured_inference/api.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI, File, status, Request, UploadFile, Form, HTTPException
 from unstructured_inference.inference.layout import process_data_with_model
 from unstructured_inference.models import UnknownModelException
-from typing import List, BinaryIO, Optional, Union
+from typing import List
 
 app = FastAPI()
 

--- a/unstructured_inference/api.py
+++ b/unstructured_inference/api.py
@@ -6,24 +6,20 @@ from typing import List, BinaryIO, Optional, Union
 app = FastAPI()
 
 ALL_ELEMS = "_ALL"
+VALID_FILETYPES = ["pdf", "image"]
 
 
-@app.post("/layout/pdf")
-async def layout_parsing_pdf(
+@app.post("/layout/{filetype:path}")
+async def layout_parsing(
+    filetype: str,
     file: UploadFile = File(),
     include_elems: List[str] = Form(default=ALL_ELEMS),
     model: str = Form(default=None),
 ):
-    return get_pages_layout(file.file, model, include_elems)
-
-
-@app.post("/layout/image")
-async def layout_parsing_image(
-    file: UploadFile = File(),
-    include_elems: List[str] = Form(default=ALL_ELEMS),
-    model: str = Form(default=None),
-):
-    return get_pages_layout(file.file, model, include_elems, is_image=True)
+    if filetype not in VALID_FILETYPES:
+        raise HTTPException(status.HTTP_404_NOT_FOUND)
+    is_image = filetype == "image"
+    return get_pages_layout(file.file, model, include_elems, is_image=is_image)
 
 
 def get_pages_layout(

--- a/unstructured_inference/api.py
+++ b/unstructured_inference/api.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI, File, status, Request, UploadFile, Form, HTTPException
-from unstructured_inference.inference.layout import process_data_with_model, DocumentLayout
+from unstructured_inference.inference.layout import process_data_with_model
 from unstructured_inference.models import UnknownModelException
 from typing import List, BinaryIO, Optional, Union
 

--- a/unstructured_inference/api.py
+++ b/unstructured_inference/api.py
@@ -19,17 +19,8 @@ async def layout_parsing(
     if filetype not in VALID_FILETYPES:
         raise HTTPException(status.HTTP_404_NOT_FOUND)
     is_image = filetype == "image"
-    return get_pages_layout(file.file, model, include_elems, is_image=is_image)
-
-
-def get_pages_layout(
-    file: BinaryIO,
-    model: Optional[str],
-    include_elems: Union[List[str], str] = ALL_ELEMS,
-    is_image=False,
-):
     try:
-        layout = process_data_with_model(file, model, is_image)
+        layout = process_data_with_model(file.file, model, is_image)
     except UnknownModelException as e:
         raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, str(e))
     pages_layout = [

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -159,21 +159,29 @@ class PageLayout:
         return self.image_array
 
 
-def process_data_with_model(data: BinaryIO, model_name: str) -> DocumentLayout:
+def process_data_with_model(
+    data: BinaryIO, model_name: str, is_image: bool = False
+) -> DocumentLayout:
     """Processes pdf file in the form of a file handler (supporting a read method) into a
     DocumentLayout by using a model identified by model_name."""
     with tempfile.NamedTemporaryFile() as tmp_file:
         tmp_file.write(data.read())
-        layout = process_file_with_model(tmp_file.name, model_name)
+        layout = process_file_with_model(tmp_file.name, model_name, is_image=is_image)
 
     return layout
 
 
-def process_file_with_model(filename: str, model_name: str) -> DocumentLayout:
+def process_file_with_model(
+    filename: str, model_name: str, is_image: bool = False
+) -> DocumentLayout:
     """Processes pdf file with name filename into a DocumentLayout by using a model identified by
     model_name."""
     model = None if model_name is None else get_model(model_name)
-    layout = DocumentLayout.from_file(filename, model=model)
+    layout = (
+        DocumentLayout.from_image_file(filename, model=model)
+        if is_image
+        else DocumentLayout.from_file(filename, model=model)
+    )
     return layout
 
 

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -196,6 +196,7 @@ def cid_ratio(text: str) -> float:
 
 
 def is_cid_present(text: str) -> bool:
+    """Checks if a cid code is present in a text selection."""
     if len(text) < len("(cid:x)"):
         return False
     return text.find("(cid:") != -1

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -160,7 +160,7 @@ class PageLayout:
 
 
 def process_data_with_model(
-    data: BinaryIO, model_name: str, is_image: bool = False
+    data: BinaryIO, model_name: Optional[str], is_image: bool = False
 ) -> DocumentLayout:
     """Processes pdf file in the form of a file handler (supporting a read method) into a
     DocumentLayout by using a model identified by model_name."""
@@ -172,7 +172,7 @@ def process_data_with_model(
 
 
 def process_file_with_model(
-    filename: str, model_name: str, is_image: bool = False
+    filename: str, model_name: Optional[str], is_image: bool = False
 ) -> DocumentLayout:
     """Processes pdf file with name filename into a DocumentLayout by using a model identified by
     model_name."""


### PR DESCRIPTION
Prepping release I realized some changes I thought I'd made never got in.
- Added `is_image` flag for `process_data_with_model` and `process_file_with_model`
- Added support for the above in the API
- Added testing for all of the above

#### Testing:

Run from python terminal:
```python
from unstructured_inference.inference.layout import process_file_with_model

res = process_file_with_model('sample-docs/loremipsum.png', is_image=True)
res.pages[0].elements
print(res)

```
The output should show that several `Text` elements were found.

Run `make run-app-dev` and from a separate terminal make the following request:
```bash
curl -X 'POST' \
  'http://localhost:8000/layout/image' \
  -H 'accept: application/json' \
  -H 'Content-Type: multipart/form-data' \
  -F 'file=@sample-docs/loremipsum.png' | jq -C . | less -R

```
The output should show that several `Text` elements were found.