### PR TITLE
chore: raise file not found for images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## 0.2.4-dev1
 
 * Clarify error when trying to open file that doesn't exist as an image
-* Requirements bumps (delete this line with first real CHANGELOG cahnge)
 
 ## 0.2.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 0.2.4-dev0
+## 0.2.4-dev1
 
+* Clarify error when trying to open file that doesn't exist as an image
 * Requirements bumps (delete this line with first real CHANGELOG cahnge)
 
 ## 0.2.3

--- a/test_unstructured_inference/inference/test_layout.py
+++ b/test_unstructured_inference/inference/test_layout.py
@@ -1,4 +1,5 @@
 import pytest
+import tempfile
 from unittest.mock import patch, mock_open
 
 import layoutparser as lp
@@ -272,3 +273,8 @@ def test_from_image_file(monkeypatch, mock_page_layout, filetype):
 def test_from_image_file_raises_with_empty_fn():
     with pytest.raises(FileNotFoundError):
         layout.DocumentLayout.from_image_file("")
+
+
+def test_from_image_file_raises_isadirectoryerror_with_dir():
+    with tempfile.TemporaryDirectory() as tempdir, pytest.raises(IsADirectoryError):
+        layout.DocumentLayout.from_image_file(tempdir)

--- a/test_unstructured_inference/inference/test_layout.py
+++ b/test_unstructured_inference/inference/test_layout.py
@@ -267,3 +267,8 @@ def test_from_image_file(monkeypatch, mock_page_layout, filetype):
         .elements
     )
     assert elements[0] == mock_page_layout
+
+
+def test_from_image_file_raises_with_empty_fn():
+    with pytest.raises(FileNotFoundError):
+        layout.DocumentLayout.from_image_file("")

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.2.4-dev0"  # pragma: no cover
+__version__ = "0.2.4-dev1"  # pragma: no cover

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+import os
 import re
 import tempfile
 from typing import List, Optional, Tuple, Union, BinaryIO
@@ -76,7 +77,13 @@ class DocumentLayout:
     def from_image_file(cls, filename: str, model: Optional[Detectron2LayoutModel] = None):
         """Creates a DocumentLayout from an image file."""
         logger.info(f"Reading image file: {filename} ...")
-        image = Image.open(filename)
+        try:
+            image = Image.open(filename)
+        except Exception as e:
+            if os.path.isdir(filename) or os.path.isfile(filename):
+                raise e
+            else:
+                raise FileNotFoundError(f"File {filename} not found!") from e
         page = PageLayout(number=0, image=image, layout=None, model=model)
         page.get_elements()
         return cls.from_pages([page])

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -83,7 +83,7 @@ class DocumentLayout:
             if os.path.isdir(filename) or os.path.isfile(filename):
                 raise e
             else:
-                raise FileNotFoundError(f"File {filename} not found!") from e
+                raise FileNotFoundError(f'File "{filename}" not found!') from e
         page = PageLayout(number=0, image=image, layout=None, model=model)
         page.get_elements()
         return cls.from_pages([page])


### PR DESCRIPTION
When trying to open an image in the `from_image_file` method, trying to open an empty filename would produce some non-helpful error, when ideally it should raise `FileNotFoundError`. This PR ensures that a `FileNotFoundError` is raised.

#### Testing:
With `main` branch active, run:
```python
from unstructured_inference.inference.layout import DocumentLayout

DocumentLayout.from_image_file("")

```
Observe that you get an `AttributeError`. Run the code again from this branch, observe that you get a `FileNotFoundError`.