### PR TITLE
refactor: generic model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.5-dev0
+
+* Add generic model interface
+
 ## 0.2.4
 
 * Download default model from huggingface

--- a/test_unstructured_inference/inference/test_layout.py
+++ b/test_unstructured_inference/inference/test_layout.py
@@ -1,3 +1,4 @@
+from functools import partial
 import pytest
 import tempfile
 from unittest.mock import patch, mock_open
@@ -64,15 +65,15 @@ class MockLayoutModel:
     def __call__(self, *args):
         return self.layout
 
+    def initialize(self, *args, **kwargs):
+        pass
+
 
 def test_get_page_elements(monkeypatch, mock_page_layout):
-    monkeypatch.setattr(
-        models, "load_detectron_model", lambda *args, **kwargs: MockLayoutModel(mock_page_layout)
-    )
-    monkeypatch.setattr(detectron2, "is_detectron2_available", lambda *args: True)
-
     image = np.random.randint(12, 24, (40, 40))
-    page = layout.PageLayout(number=0, image=image, layout=mock_page_layout)
+    page = layout.PageLayout(
+        number=0, image=image, layout=mock_page_layout, model=MockLayoutModel(mock_page_layout)
+    )
 
     elements = page.get_elements(inplace=False)
 
@@ -84,19 +85,23 @@ def test_get_page_elements(monkeypatch, mock_page_layout):
 
 
 def test_get_page_elements_with_ocr(monkeypatch):
-    monkeypatch.setattr(layout.PageLayout, "ocr", lambda *args: "An Even Catchier Title")
 
     rectangle = Rectangle(2, 4, 6, 8)
     text_block = TextBlock(rectangle, text=None, type="Title")
     doc_layout = Layout([text_block])
 
     monkeypatch.setattr(
-        models, "load_detectron_model", lambda *args, **kwargs: MockLayoutModel(doc_layout)
+        detectron2,
+        "UnstructuredDetectronModel",
+        lambda *args, **kwargs: MockLayoutModel(doc_layout),
     )
     monkeypatch.setattr(detectron2, "is_detectron2_available", lambda *args: True)
+    monkeypatch.setattr(layout.PageLayout, "ocr", lambda *args: "An Even Catchier Title")
 
     image = np.random.randint(12, 24, (40, 40))
-    page = layout.PageLayout(number=0, image=image, layout=doc_layout)
+    page = layout.PageLayout(
+        number=0, image=image, layout=doc_layout, model=MockLayoutModel(doc_layout)
+    )
     page.get_elements()
 
     assert str(page) == "An Even Catchier Title"
@@ -108,8 +113,11 @@ def test_read_pdf(monkeypatch, mock_page_layout):
 
     layouts = Layout([mock_page_layout, mock_page_layout])
 
+    def mock_initialize(self, *args, **kwargs):
+        self.model = MockLayoutModel(mock_page_layout)
+
     monkeypatch.setattr(
-        models, "load_detectron_model", lambda *args, **kwargs: MockLayoutModel(mock_page_layout)
+        models, "UnstructuredDetectronModel", partial(MockLayoutModel, layout=mock_page_layout)
     )
     monkeypatch.setattr(detectron2, "is_detectron2_available", lambda *args: True)
 
@@ -146,15 +154,16 @@ def test_process_data_with_model_raises_on_invalid_model_name():
 
 @pytest.mark.parametrize("model_name", [None, "checkbox"])
 def test_process_file_with_model(monkeypatch, mock_page_layout, model_name):
+    def mock_initialize(self, *args, **kwargs):
+        self.model = MockLayoutModel(mock_page_layout)
+
     monkeypatch.setattr(models, "get_model", lambda x: MockLayoutModel(mock_page_layout))
     monkeypatch.setattr(
         layout.DocumentLayout,
         "from_file",
         lambda *args, **kwargs: layout.DocumentLayout.from_pages([]),
     )
-    monkeypatch.setattr(
-        models, "load_detectron_model", lambda *args, **kwargs: MockLayoutModel(mock_page_layout)
-    )
+    monkeypatch.setattr(models.UnstructuredDetectronModel, "initialize", mock_initialize)
     filename = ""
     assert layout.process_file_with_model(filename, model_name=model_name)
 

--- a/test_unstructured_inference/inference/test_layout.py
+++ b/test_unstructured_inference/inference/test_layout.py
@@ -61,13 +61,13 @@ class MockLayoutModel:
     def __init__(self, layout):
         self.layout = layout
 
-    def detect(self, *args):
+    def __call__(self, *args):
         return self.layout
 
 
 def test_get_page_elements(monkeypatch, mock_page_layout):
     monkeypatch.setattr(
-        models, "load_model", lambda *args, **kwargs: MockLayoutModel(mock_page_layout)
+        models, "load_detectron_model", lambda *args, **kwargs: MockLayoutModel(mock_page_layout)
     )
     monkeypatch.setattr(detectron2, "is_detectron2_available", lambda *args: True)
 
@@ -90,7 +90,9 @@ def test_get_page_elements_with_ocr(monkeypatch):
     text_block = TextBlock(rectangle, text=None, type="Title")
     doc_layout = Layout([text_block])
 
-    monkeypatch.setattr(models, "load_model", lambda *args, **kwargs: MockLayoutModel(doc_layout))
+    monkeypatch.setattr(
+        models, "load_detectron_model", lambda *args, **kwargs: MockLayoutModel(doc_layout)
+    )
     monkeypatch.setattr(detectron2, "is_detectron2_available", lambda *args: True)
 
     image = np.random.randint(12, 24, (40, 40))
@@ -107,11 +109,11 @@ def test_read_pdf(monkeypatch, mock_page_layout):
     layouts = Layout([mock_page_layout, mock_page_layout])
 
     monkeypatch.setattr(
-        models, "load_model", lambda *args, **kwargs: MockLayoutModel(mock_page_layout)
+        models, "load_detectron_model", lambda *args, **kwargs: MockLayoutModel(mock_page_layout)
     )
     monkeypatch.setattr(detectron2, "is_detectron2_available", lambda *args: True)
 
-    with patch.object(lp, "load_pdf", return_value=(layouts, images)):
+    with patch.object(layout, "load_pdf", return_value=(layouts, images)):
         doc = layout.DocumentLayout.from_file("fake-file.pdf")
 
         assert str(doc).startswith("A Catchy Title")
@@ -126,24 +128,11 @@ def test_read_pdf(monkeypatch, mock_page_layout):
 
 @pytest.mark.parametrize("model_name", [None, "checkbox", "fake"])
 def test_process_data_with_model(monkeypatch, mock_page_layout, model_name):
-    monkeypatch.setattr(models, "get_model", lambda x: MockLayoutModel(mock_page_layout))
+    monkeypatch.setattr(layout, "get_model", lambda x: MockLayoutModel(mock_page_layout))
     monkeypatch.setattr(
         layout.DocumentLayout,
         "from_file",
         lambda *args, **kwargs: layout.DocumentLayout.from_pages([]),
-    )
-    monkeypatch.setattr(
-        models, "load_model", lambda *args, **kwargs: MockLayoutModel(mock_page_layout)
-    )
-    monkeypatch.setattr(
-        models,
-        "_get_model_loading_info",
-        lambda *args, **kwargs: (
-            "fake-binary-path",
-            "fake-config-path",
-            {0: "Unchecked", 1: "Checked"},
-            None,
-        ),
     )
     with patch("builtins.open", mock_open(read_data=b"000000")):
         assert layout.process_data_with_model(open(""), model_name=model_name)
@@ -164,17 +153,7 @@ def test_process_file_with_model(monkeypatch, mock_page_layout, model_name):
         lambda *args, **kwargs: layout.DocumentLayout.from_pages([]),
     )
     monkeypatch.setattr(
-        models, "load_model", lambda *args, **kwargs: MockLayoutModel(mock_page_layout)
-    )
-    monkeypatch.setattr(
-        models,
-        "_get_model_loading_info",
-        lambda *args, **kwargs: (
-            "fake-binary-path",
-            "fake-config-path",
-            {0: "Unchecked", 1: "Checked"},
-            None,
-        ),
+        models, "load_detectron_model", lambda *args, **kwargs: MockLayoutModel(mock_page_layout)
     )
     filename = ""
     assert layout.process_file_with_model(filename, model_name=model_name)
@@ -257,9 +236,7 @@ def test_pagelayout_without_layout():
     model = MockLayoutModel(mock_layout)
     pl = MockPageLayout(model=model, layout=None)
 
-    assert [el.text for el in pl.get_elements(inplace=False)] == [
-        el.ocr_text for el in model.detect(None)
-    ]
+    assert [el.text for el in pl.get_elements(inplace=False)] == [el.ocr_text for el in model(None)]
 
 
 @pytest.mark.parametrize("filetype", ("png", "jpg"))

--- a/test_unstructured_inference/models/test_detectron2.py
+++ b/test_unstructured_inference/models/test_detectron2.py
@@ -11,7 +11,11 @@ class MockDetectron2LayoutModel:
         self.kwargs = kwargs
 
     def detect(self, x):
-        return "called"
+        return MockLayout()
+
+
+class MockLayout:
+    pass
 
 
 def test_load_default_model(monkeypatch):
@@ -40,4 +44,4 @@ def test_load_model(monkeypatch, config_path, model_path):
 
 def test_unstructured_detectron_model():
     model = detectron2.UnstructuredDetectronModel(MockDetectron2LayoutModel())
-    assert model(None) == "called"
+    assert isinstance(model(None), MockLayout)

--- a/test_unstructured_inference/models/test_detectron2.py
+++ b/test_unstructured_inference/models/test_detectron2.py
@@ -17,7 +17,7 @@ def test_load_default_model(monkeypatch):
     with patch.object(detectron2, "is_detectron2_available", return_value=True):
         model = models.get_model()
 
-    assert isinstance(model, MockDetectron2LayoutModel)
+    assert isinstance(model.model, MockDetectron2LayoutModel)
 
 
 def test_load_default_model_raises_when_not_available():
@@ -31,5 +31,5 @@ def test_load_model(monkeypatch, config_path, model_path):
     monkeypatch.setattr(detectron2, "Detectron2LayoutModel", MockDetectron2LayoutModel)
     with patch.object(detectron2, "is_detectron2_available", return_value=True):
         model = detectron2.load_model(config_path=config_path, model_path=model_path)
-    assert config_path == model.args[0]
-    assert model_path == model.kwargs["model_path"]
+    assert config_path == model.model.args[0]
+    assert model_path == model.model.kwargs["model_path"]

--- a/test_unstructured_inference/models/test_detectron2.py
+++ b/test_unstructured_inference/models/test_detectron2.py
@@ -10,6 +10,9 @@ class MockDetectron2LayoutModel:
         self.args = args
         self.kwargs = kwargs
 
+    def detect(self, x):
+        return "called"
+
 
 def test_load_default_model(monkeypatch):
     monkeypatch.setattr(detectron2, "Detectron2LayoutModel", MockDetectron2LayoutModel)
@@ -33,3 +36,8 @@ def test_load_model(monkeypatch, config_path, model_path):
         model = detectron2.load_model(config_path=config_path, model_path=model_path)
     assert config_path == model.model.args[0]
     assert model_path == model.model.kwargs["model_path"]
+
+
+def test_unstructured_detectron_model():
+    model = detectron2.UnstructuredDetectronModel(MockDetectron2LayoutModel())
+    assert model(None) == "called"

--- a/test_unstructured_inference/models/test_detectron2.py
+++ b/test_unstructured_inference/models/test_detectron2.py
@@ -37,11 +37,13 @@ def test_load_default_model_raises_when_not_available():
 def test_load_model(monkeypatch, config_path, model_path):
     monkeypatch.setattr(detectron2, "Detectron2LayoutModel", MockDetectron2LayoutModel)
     with patch.object(detectron2, "is_detectron2_available", return_value=True):
-        model = detectron2.load_model(config_path=config_path, model_path=model_path)
+        model = detectron2.UnstructuredDetectronModel()
+        model.initialize(config_path=config_path, model_path=model_path)
     assert config_path == model.model.args[0]
     assert model_path == model.model.kwargs["model_path"]
 
 
 def test_unstructured_detectron_model():
-    model = detectron2.UnstructuredDetectronModel(MockDetectron2LayoutModel())
+    model = detectron2.UnstructuredDetectronModel()
+    model.model = MockDetectron2LayoutModel()
     assert isinstance(model(None), MockLayout)

--- a/test_unstructured_inference/models/test_model.py
+++ b/test_unstructured_inference/models/test_model.py
@@ -1,17 +1,20 @@
 import pytest
 
 import unstructured_inference.models.base as models
+from unstructured_inference.models.unstructuredmodel import ModelNotInitializedError
 
 
 class MockModel:
-    def __init__(self, *args, **kwargs):
-        self.args = args
-        self.kwargs = kwargs
+    def initialize(self, *args, **kwargs):
+        pass
 
 
 def test_get_model(monkeypatch):
+
     monkeypatch.setattr(
-        models, "load_detectron_model", lambda *args, **kwargs: MockModel(*args, **kwargs)
+        models,
+        "UnstructuredDetectronModel",
+        MockModel,
     )
     assert isinstance(models.get_model("checkbox"), MockModel)
 
@@ -19,3 +22,8 @@ def test_get_model(monkeypatch):
 def test_raises_invalid_model():
     with pytest.raises(models.UnknownModelException):
         models.get_model("fake_model")
+
+
+def test_raises_uninitialized():
+    with pytest.raises(ModelNotInitializedError):
+        models.UnstructuredDetectronModel().predict(None)

--- a/test_unstructured_inference/models/test_model.py
+++ b/test_unstructured_inference/models/test_model.py
@@ -10,16 +10,8 @@ class MockModel:
 
 
 def test_get_model(monkeypatch):
-    monkeypatch.setattr(models, "load_model", lambda *args, **kwargs: MockModel(*args, **kwargs))
     monkeypatch.setattr(
-        models,
-        "_get_model_loading_info",
-        lambda *args, **kwargs: (
-            "fake-binary-path",
-            "fake-config-path",
-            {0: "Unchecked", 1: "Checked"},
-            None,
-        ),
+        models, "load_detectron_model", lambda *args, **kwargs: MockModel(*args, **kwargs)
     )
     assert isinstance(models.get_model("checkbox"), MockModel)
 

--- a/test_unstructured_inference/test_api.py
+++ b/test_unstructured_inference/test_api.py
@@ -3,10 +3,9 @@ import os
 
 from fastapi.testclient import TestClient
 
-from unstructured_inference.api import app
+from unstructured_inference import api
 from unstructured_inference.models import base as models
 from unstructured_inference.inference.layout import DocumentLayout
-import unstructured_inference.models.detectron2 as detectron2
 
 
 class MockModel:
@@ -15,47 +14,45 @@ class MockModel:
         self.kwargs = kwargs
 
 
+def get_doc_layout(*args, **kwargs):
+    return DocumentLayout.from_pages([])
+
+
+def raise_unknown_model_exception(*args, **kwargs):
+    raise models.UnknownModelException()
+
+
 @pytest.mark.parametrize(
-    "filetype, ext, data, response_code",
+    "filetype, ext, data, process_func, expected_response_code",
     [
-        ("pdf", "pdf", None, 200),
-        ("pdf", "pdf", {"model": "checkbox"}, 200),
-        ("pdf", "pdf", {"model": "fake_model"}, 422),
-        ("image", "png", None, 200),
-        ("image", "png", {"model": "checkbox"}, 200),
-        ("image", "png", {"model": "fake_model"}, 422),
+        ("pdf", "pdf", None, get_doc_layout, 200),
+        ("pdf", "pdf", {"model": "checkbox"}, get_doc_layout, 200),
+        ("pdf", "pdf", {"model": "fake_model"}, raise_unknown_model_exception, 422),
+        ("image", "png", None, get_doc_layout, 200),
+        ("image", "png", {"model": "checkbox"}, get_doc_layout, 200),
+        ("image", "png", {"model": "fake_model"}, raise_unknown_model_exception, 422),
     ],
 )
-def test_layout_parsing_api(monkeypatch, filetype, ext, data, response_code):
-    monkeypatch.setattr(
-        models, "load_detectron_model", lambda *args, **kwargs: MockModel(*args, **kwargs)
-    )
-    monkeypatch.setattr(detectron2, "hf_hub_download", lambda *args, **kwargs: "fake-path")
-    monkeypatch.setattr(detectron2, "is_detectron2_available", lambda *args: True)
-    monkeypatch.setattr(
-        DocumentLayout, "from_file", lambda *args, **kwargs: DocumentLayout.from_pages([])
-    )
-    monkeypatch.setattr(
-        DocumentLayout, "from_image_file", lambda *args, **kwargs: DocumentLayout.from_pages([])
-    )
+def test_layout_parsing_api(monkeypatch, filetype, ext, data, process_func, expected_response_code):
+    monkeypatch.setattr(api, "process_data_with_model", process_func)
 
     filename = os.path.join("sample-docs", f"loremipsum.{ext}")
 
-    client = TestClient(app)
+    client = TestClient(api.app)
     response = client.post(
         f"/layout/{filetype}", files={"file": (filename, open(filename, "rb"))}, data=data
     )
-    assert response.status_code == response_code
+    assert response.status_code == expected_response_code
 
 
 def test_bad_route_404():
-    client = TestClient(app)
+    client = TestClient(api.app)
     filename = os.path.join("sample-docs", "loremipsum.pdf")
     response = client.post("/layout/badroute", files={"file": (filename, open(filename, "rb"))})
     assert response.status_code == 404
 
 
 def test_healthcheck(monkeypatch):
-    client = TestClient(app)
+    client = TestClient(api.app)
     response = client.get("/healthcheck")
     assert response.status_code == 200

--- a/test_unstructured_inference/test_api.py
+++ b/test_unstructured_inference/test_api.py
@@ -27,8 +27,10 @@ class MockModel:
     ],
 )
 def test_layout_parsing_api(monkeypatch, filetype, ext, data, response_code):
-    monkeypatch.setattr(models, "load_model", lambda *args, **kwargs: MockModel(*args, **kwargs))
-    monkeypatch.setattr(models, "hf_hub_download", lambda *args, **kwargs: "fake-path")
+    monkeypatch.setattr(
+        models, "load_detectron_model", lambda *args, **kwargs: MockModel(*args, **kwargs)
+    )
+    monkeypatch.setattr(detectron2, "hf_hub_download", lambda *args, **kwargs: "fake-path")
     monkeypatch.setattr(detectron2, "is_detectron2_available", lambda *args: True)
     monkeypatch.setattr(
         DocumentLayout, "from_file", lambda *args, **kwargs: DocumentLayout.from_pages([])

--- a/test_unstructured_inference/test_utils.py
+++ b/test_unstructured_inference/test_utils.py
@@ -1,0 +1,44 @@
+import pytest
+from unstructured_inference.utils import LazyDict, LazyEvaluateInfo
+
+
+def test_dict_same():
+    d = {"a": 1, "b": 2, "c": 3}
+    ld = LazyDict(**d)
+    assert all(kd == kld for kd, kld in zip(d, ld))
+    assert all(d[k] == ld[k] for k in d)
+    assert len(ld) == len(d)
+
+
+def test_lazy_evaluate():
+    called = 0
+
+    def func(x):
+        nonlocal called
+        called += 1
+        return x
+
+    lei = LazyEvaluateInfo(func, 3)
+    assert called == 0
+    ld = LazyDict(a=lei)
+    assert called == 0
+    assert ld["a"] == 3
+    assert called == 1
+
+
+@pytest.mark.parametrize("cache, expected", [(True, 1), (False, 2)])
+def test_caches(cache, expected):
+    called = 0
+
+    def func(x):
+        nonlocal called
+        called += 1
+        return x
+
+    lei = LazyEvaluateInfo(func, 3)
+    assert called == 0
+    ld = LazyDict(cache=cache, a=lei)
+    assert called == 0
+    assert ld["a"] == 3
+    assert ld["a"] == 3
+    assert called == expected

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.2.4"  # pragma: no cover
+__version__ = "0.2.5-dev0"  # pragma: no cover

--- a/unstructured_inference/models/base.py
+++ b/unstructured_inference/models/base.py
@@ -1,51 +1,19 @@
-from typing import Tuple, Dict, Optional, List, Any
-from huggingface_hub import hf_hub_download
+from typing import Optional
+from unstructured_inference.models.unstructuredmodel import UnstructuredModel
 
 from unstructured_inference.models.detectron2 import (
-    load_model,
-    Detectron2LayoutModel,
-    DEFAULT_LABEL_MAP,
-    DEFAULT_EXTRA_CONFIG,
+    MODEL_TYPES as DETECTRON2_MODEL_TYPES,
+    load_model as load_detectron_model,
 )
 
 
-def get_model(model: Optional[str] = None) -> Detectron2LayoutModel:
+def get_model(model_name: Optional[str] = None) -> UnstructuredModel:
     """Gets the model object by model name."""
-    model_path, config_path, label_map, extra_config = _get_model_loading_info(model)
-    detector = load_model(
-        config_path=config_path,
-        model_path=model_path,
-        label_map=label_map,
-        extra_config=extra_config,
-    )
-    return detector
-
-
-def _get_model_loading_info(
-    model: Optional[str],
-) -> Tuple[str, str, Dict[int, str], Optional[List[Any]]]:
-    """Gets local model binary and config locations and label map, downloading if necessary."""
-    # TODO(alan): Find the right way to map model name to retrieval. It seems off that testing
-    # needs to mock hf_hub_download.
-    if model is None:
-        repo_id = "layoutparser/detectron2"
-        binary_fn = "PubLayNet/faster_rcnn_R_50_FPN_3x/model_final.pth"
-        config_fn = "PubLayNet/faster_rcnn_R_50_FPN_3x/config.yml"
-        model_path = hf_hub_download(repo_id, binary_fn)
-        config_path = hf_hub_download(repo_id, config_fn)
-        label_map = DEFAULT_LABEL_MAP
-        extra_config = DEFAULT_EXTRA_CONFIG
-    elif model == "checkbox":
-        repo_id = "unstructuredio/oer-checkbox"
-        binary_fn = "detectron2_finetuned_oer_checkbox.pth"
-        config_fn = "detectron2_oer_checkbox.json"
-        model_path = hf_hub_download(repo_id, binary_fn)
-        config_path = hf_hub_download(repo_id, config_fn)
-        label_map = {0: "Unchecked", 1: "Checked"}
-        extra_config = None
+    if model_name in DETECTRON2_MODEL_TYPES:
+        model = load_detectron_model(**DETECTRON2_MODEL_TYPES[model_name])
     else:
-        raise UnknownModelException(f"Unknown model type: {model}")
-    return model_path, config_path, label_map, extra_config
+        raise UnknownModelException(f"Unknown model type: {model_name}")
+    return model
 
 
 class UnknownModelException(Exception):

--- a/unstructured_inference/models/base.py
+++ b/unstructured_inference/models/base.py
@@ -3,14 +3,15 @@ from unstructured_inference.models.unstructuredmodel import UnstructuredModel
 
 from unstructured_inference.models.detectron2 import (
     MODEL_TYPES as DETECTRON2_MODEL_TYPES,
-    load_model as load_detectron_model,
+    UnstructuredDetectronModel,
 )
 
 
 def get_model(model_name: Optional[str] = None) -> UnstructuredModel:
     """Gets the model object by model name."""
     if model_name in DETECTRON2_MODEL_TYPES:
-        model = load_detectron_model(**DETECTRON2_MODEL_TYPES[model_name])
+        model = UnstructuredDetectronModel()
+        model.initialize(**DETECTRON2_MODEL_TYPES[model_name])
     else:
         raise UnknownModelException(f"Unknown model type: {model_name}")
     return model

--- a/unstructured_inference/models/detectron2.py
+++ b/unstructured_inference/models/detectron2.py
@@ -58,36 +58,33 @@ MODEL_TYPES = {
 class UnstructuredDetectronModel(UnstructuredModel):
     """Unstructured model wrapper for Detectron2LayoutModel."""
 
-    def __init__(self, model: Detectron2LayoutModel):
-        super().__init__(model)
-
-    def __call__(self, x: Image):
+    def predict(self, x: Image):
+        super().predict(x)
         return self.model.detect(x)
 
+    def initialize(
+        self,
+        config_path: Union[str, Path, LayoutModelConfig],
+        model_path: Optional[Union[str, Path]] = None,
+        label_map: Optional[Dict[int, str]] = None,
+        extra_config: Optional[list] = None,
+        device: Optional[str] = None,
+    ):
+        """Loads the detectron2 model using the specified parameters"""
 
-def load_model(
-    config_path: Union[str, Path, LayoutModelConfig],
-    model_path: Optional[Union[str, Path]] = None,
-    label_map: Optional[Dict[int, str]] = None,
-    extra_config: Optional[list] = None,
-    device: Optional[str] = None,
-) -> Detectron2LayoutModel:
-    """Loads the detectron2 model using the specified parameters"""
+        if not is_detectron2_available():
+            raise ImportError(
+                "Failed to load the Detectron2 model. Ensure that the Detectron2 "
+                "module is correctly installed."
+            )
 
-    if not is_detectron2_available():
-        raise ImportError(
-            "Failed to load the Detectron2 model. Ensure that the Detectron2 "
-            "module is correctly installed."
+        config_path_str = str(config_path)
+        model_path_str: Optional[str] = None if model_path is None else str(model_path)
+        logger.info("Loading the Detectron2 layout model ...")
+        self.model = Detectron2LayoutModel(
+            config_path_str,
+            model_path=model_path_str,
+            label_map=label_map,
+            extra_config=extra_config,
+            device=device,
         )
-
-    config_path_str = str(config_path)
-    model_path_str: Optional[str] = None if model_path is None else str(model_path)
-    logger.info("Loading the Detectron2 layout model ...")
-    model = Detectron2LayoutModel(
-        config_path_str,
-        model_path=model_path_str,
-        label_map=label_map,
-        extra_config=extra_config,
-        device=device,
-    )
-    return UnstructuredDetectronModel(model)

--- a/unstructured_inference/models/detectron2.py
+++ b/unstructured_inference/models/detectron2.py
@@ -55,6 +55,8 @@ MODEL_TYPES = {
 
 
 class UnstructuredDetectronModel(UnstructuredModel):
+    """Unstructured model wrapper for Detectron2LayoutModel."""
+
     def __call__(self, x):
         return self.model.detect(x)
 

--- a/unstructured_inference/models/detectron2.py
+++ b/unstructured_inference/models/detectron2.py
@@ -6,6 +6,7 @@ from layoutparser.models.detectron2.layoutmodel import (
     Detectron2LayoutModel,
 )
 from layoutparser.models.model_config import LayoutModelConfig
+from PIL import Image
 from huggingface_hub import hf_hub_download
 
 from unstructured_inference.logger import logger
@@ -57,7 +58,10 @@ MODEL_TYPES = {
 class UnstructuredDetectronModel(UnstructuredModel):
     """Unstructured model wrapper for Detectron2LayoutModel."""
 
-    def __call__(self, x):
+    def __init__(self, model: Detectron2LayoutModel):
+        super().__init__(model)
+
+    def __call__(self, x: Image):
         return self.model.detect(x)
 
 

--- a/unstructured_inference/models/unstructuredmodel.py
+++ b/unstructured_inference/models/unstructuredmodel.py
@@ -11,4 +11,4 @@ class UnstructuredModel(ABC):
 
     @abstractmethod
     def __call__(self, x: Image) -> Any:
-        pass
+        pass  # pragma: no cover

--- a/unstructured_inference/models/unstructuredmodel.py
+++ b/unstructured_inference/models/unstructuredmodel.py
@@ -5,13 +5,31 @@ from typing import Any
 class UnstructuredModel(ABC):
     """Wrapper class for the various models used by unstructured."""
 
-    def __init__(self, model: Any):
+    def __init__(self):
         """model should support inference of some sort, either by calling or by some method.
         UnstructuredModel doesn't provide any training interface, it's assumed the model is
         already trained.
         """
-        self.model = model
+        self.model = None
 
     @abstractmethod
-    def __call__(self, x: Any) -> Any:
+    def predict(self, x: Any) -> Any:
+        """Do inference using the wrapped model."""
+        if self.model is None:
+            raise ModelNotInitializedError(
+                "Model has not been initialized. Please call the initialize method with the "
+                "appropriate arguments for loading the model."
+            )
         pass  # pragma: no cover
+
+    def __call__(self, x: Any):
+        return self.predict(x)
+
+    @abstractmethod
+    def initialize(self, *args, **kwargs):
+        """Load the model for inference."""
+        pass  # pragma: no cover
+
+
+class ModelNotInitializedError(Exception):
+    pass

--- a/unstructured_inference/models/unstructuredmodel.py
+++ b/unstructured_inference/models/unstructuredmodel.py
@@ -1,0 +1,14 @@
+from abc import ABC, abstractmethod
+from typing import Any
+from PIL import Image
+
+
+class UnstructuredModel(ABC):
+    """Wrapper class for the various models used by unstructured."""
+
+    def __init__(self, model: Any):
+        self.model = model
+
+    @abstractmethod
+    def __call__(self, x: Image) -> Any:
+        pass

--- a/unstructured_inference/models/unstructuredmodel.py
+++ b/unstructured_inference/models/unstructuredmodel.py
@@ -1,14 +1,17 @@
 from abc import ABC, abstractmethod
 from typing import Any
-from PIL import Image
 
 
 class UnstructuredModel(ABC):
     """Wrapper class for the various models used by unstructured."""
 
     def __init__(self, model: Any):
+        """model should support inference of some sort, either by calling or by some method.
+        UnstructuredModel doesn't provide any training interface, it's assumed the model is
+        already trained.
+        """
         self.model = model
 
     @abstractmethod
-    def __call__(self, x: Image) -> Any:
+    def __call__(self, x: Any) -> Any:
         pass  # pragma: no cover

--- a/unstructured_inference/utils.py
+++ b/unstructured_inference/utils.py
@@ -3,6 +3,10 @@ from typing import Any, Hashable, Union, Iterator, Callable
 
 
 class LazyEvaluateInfo:
+    """Class that stores the information needed to lazily evaluate a function with given arguments.
+    The object stores the information needed for evaluation as a function and its arguments.
+    """
+
     def __init__(self, evaluate: Callable, *args, **kwargs):
         self.evaluate = evaluate
         self.info = (args, kwargs)
@@ -10,9 +14,14 @@ class LazyEvaluateInfo:
 
 class LazyDict(Mapping):
     """Class that wraps a dict and only evaluates keys of the dict when the key is accessed. Keys
-    that should be evaluated lazily should use LazyEvaluateInfo objects as values."""
+    that should be evaluated lazily should use LazyEvaluateInfo objects as values. By default when
+    a value is computed from a LazyEvaluateInfo object, it is converted to the raw value in the
+    internal dict, so subsequent accessing of the key will produce the same value. Set cache=False
+    to avoid storing the raw value.
+    """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, cache=True, **kwargs):
+        self.cache = cache
         self._raw_dict = dict(*args, **kwargs)
 
     def __getitem__(self, key: Hashable) -> Union[LazyEvaluateInfo, Any]:
@@ -20,9 +29,10 @@ class LazyDict(Mapping):
         if isinstance(value, LazyEvaluateInfo):
             evaluate = value.evaluate
             args, kwargs = value.info
-            return evaluate(*args, **kwargs)
-        else:
-            return value
+            value = evaluate(*args, **kwargs)
+            if self.cache:
+                self._raw_dict[key] = value
+        return value
 
     def __iter__(self) -> Iterator:
         return iter(self._raw_dict)

--- a/unstructured_inference/utils.py
+++ b/unstructured_inference/utils.py
@@ -1,0 +1,31 @@
+from collections.abc import Mapping
+from typing import Any, Hashable, Union, Iterator, Callable
+
+
+class LazyEvaluateInfo:
+    def __init__(self, evaluate: Callable, *args, **kwargs):
+        self.evaluate = evaluate
+        self.info = (args, kwargs)
+
+
+class LazyDict(Mapping):
+    """Class that wraps a dict and only evaluates keys of the dict when the key is accessed. Keys
+    that should be evaluated lazily should use LazyEvaluateInfo objects as values."""
+
+    def __init__(self, *args, **kwargs):
+        self._raw_dict = dict(*args, **kwargs)
+
+    def __getitem__(self, key: Hashable) -> Union[LazyEvaluateInfo, Any]:
+        value = self._raw_dict.__getitem__(key)
+        if isinstance(value, LazyEvaluateInfo):
+            evaluate = value.evaluate
+            args, kwargs = value.info
+            return evaluate(*args, **kwargs)
+        else:
+            return value
+
+    def __iter__(self) -> Iterator:
+        return iter(self._raw_dict)
+
+    def __len__(self) -> int:
+        return len(self._raw_dict)


### PR DESCRIPTION
Refactor of model code to make it less dependent on detectron2. 

Creates an abstract model class `UnstructuredModel`, with inference triggered by calling the object. The class must be subclassed for each individual model type to at least guide the inference input to the right method (e.g. the `detect` method for detectron 2 models).

Detectron specific code has been moved to `unstructured_inference.models.detectron2`.

The code still uses layoutparser objects for convenience in the `layout` code preparing the input, and the output is assumed to be a layoutparser `Layout` object. We may not want output in this format for other model types, but it seems like a viable choice for an output format, so we might consider wrangling the format to this class.

#### Testing:

Tests should be passing and the high level interface should operate as usual.