### PR TITLE
fix: remove duplicate load pdf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-## 0.2.7-dev0
+## 0.2.7
+* Fixed duplicated load_pdf call
 
 ## 0.2.6
 

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.2.7-dev0"  # pragma: no cover
+__version__ = "0.2.7"  # pragma: no cover

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -79,7 +79,6 @@ class DocumentLayout:
         # image and returns a dict, or something.
         logger.info(f"Reading PDF for file: {filename} ...")
         layouts, images = load_pdf(filename, load_images=True)
-        layouts, images = load_pdf(filename, load_images=True)
         pages: List[PageLayout] = list()
         for i, layout in enumerate(layouts):
             image = images[i]


### PR DESCRIPTION
Somehow a duplicate `load_pdf` line got in, maybe during a merge. Removed one of them.

Thanks to [hyperknot](https://github.com/hyperknot) for pointing this out in [this issue](https://github.com/Unstructured-IO/unstructured-inference/issues/51).