### PR TITLE
fix: catch len mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
+## 0.2.8-dev0
+
 ## 0.2.7
+
 * Fixed duplicated load_pdf call
 
 ## 0.2.6

--- a/test_unstructured_inference/inference/test_layout.py
+++ b/test_unstructured_inference/inference/test_layout.py
@@ -269,3 +269,10 @@ def test_from_image_file_raises_with_empty_fn():
 def test_from_image_file_raises_isadirectoryerror_with_dir():
     with tempfile.TemporaryDirectory() as tempdir, pytest.raises(IsADirectoryError):
         layout.DocumentLayout.from_image_file(tempdir)
+
+
+def test_from_file_raises_on_length_mismatch(monkeypatch):
+    monkeypatch.setattr(layout, "load_pdf", lambda *args, **kwargs: ([None, None], []))
+    with pytest.raises(RuntimeError) as e:
+        layout.DocumentLayout.from_file("fake_file")
+    assert "poppler" in str(e).lower()

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.2.7"  # pragma: no cover
+__version__ = "0.2.8-dev0"  # pragma: no cover

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -81,7 +81,7 @@ class DocumentLayout:
         layouts, images = load_pdf(filename, load_images=True)
         if len(layouts) > len(images):
             raise RuntimeError(
-                "Some images were not loaded. Check that poppler is installed and in PATH."
+                "Some images were not loaded. Check that poppler is installed and in your $PATH."
             )
         pages: List[PageLayout] = list()
         for i, layout in enumerate(layouts):

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -79,6 +79,10 @@ class DocumentLayout:
         # image and returns a dict, or something.
         logger.info(f"Reading PDF for file: {filename} ...")
         layouts, images = load_pdf(filename, load_images=True)
+        if len(layouts) > len(images):
+            raise RuntimeError(
+                "Some images were not loaded. Check that poppler is installed and in PATH."
+            )
         pages: List[PageLayout] = list()
         for i, layout in enumerate(layouts):
             image = images[i]


### PR DESCRIPTION
From [issue 51](https://github.com/Unstructured-IO/unstructured-inference/issues/51) we have a report of `load_pdf` coming back with a non-empty list of layouts and an empty list of images. The reported fix was to install poppler.

I haven't been able to reproduce yet (if I try `from_file` without poppler installed I get a `RuntimeError` with a suggestion to install poppler), but it doesn't hurt to guard against a length mismatch, as that shouldn't happen and would cause subsequent code to fail. I added an error message that points the user at a possible poppler install issue.

#### Testing:
I added a test that checks the error raises properly, so just look over the code and make sure it makes sense.