### PR TITLE
fix: removes multithreading for OCR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.9
+
+* Removed multithreading from OCR
+
 ## 0.2.8
 
 * Refactored YoloX inference code to integrate better with framework

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.2.9
 
-* Removed multithreading from OCR
+* Removed multithreading from OCR (DocumentLayout.get_elements_from_layout)
 
 ## 0.2.8
 

--- a/test_unstructured_inference/inference/test_layout.py
+++ b/test_unstructured_inference/inference/test_layout.py
@@ -101,7 +101,6 @@ def test_get_page_elements_with_ocr(monkeypatch):
 
     monkeypatch.setattr(detectron2, "is_detectron2_available", lambda *args: True)
     monkeypatch.setattr(layout, "ocr", lambda *args: "An Even Catchier Title")
-    monkeypatch.setattr(layout, "Pool", MockPool)
 
     image = Image.fromarray(np.random.randint(12, 14, size=(40, 10, 3)), mode="RGB")
     print(layout.ocr(text_block, image))

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.2.8"  # pragma: no cover
+__version__ = "0.2.9"  # pragma: no cover

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 from dataclasses import dataclass
-from functools import partial
-from multiprocessing import Pool
 import os
 import re
 import tempfile
@@ -181,7 +179,7 @@ class PageLayout:
         # NOTE(benjamin): Creates a Pool for concurrent processing of image elements by OCR
         elements = []
         for e in tqdm(layout):
-            elements.append(get_element_from_block(e,self.image,self.layout,self.ocr_strategy))
+            elements.append(get_element_from_block(e, self.image, self.layout, self.ocr_strategy))
         return elements
 
     def _get_image_array(self) -> Union[np.ndarray, None]:

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -5,6 +5,7 @@ from multiprocessing import Pool
 import os
 import re
 import tempfile
+from tqdm import tqdm
 from typing import List, Optional, Tuple, Union, BinaryIO
 
 from layoutparser.io.pdf import load_pdf
@@ -178,18 +179,9 @@ class PageLayout:
         # sophisticated ordering logic for more complicated layouts.
         layout.sort(key=lambda element: element.coordinates[1], inplace=True)
         # NOTE(benjamin): Creates a Pool for concurrent processing of image elements by OCR
-        pool = Pool()
-        try:
-            get_element_partial = partial(
-                get_element_from_block,
-                image=self.image,
-                layout=self.layout,
-                ocr_strategy=self.ocr_strategy,
-            )
-            elements = pool.map(get_element_partial, layout)
-        finally:
-            pool.close()
-            pool.join()
+        elements = []
+        for e in tqdm(layout):
+            elements.append(get_element_from_block(e,self.image,self.layout,self.ocr_strategy))
         return elements
 
     def _get_image_array(self) -> Union[np.ndarray, None]:

--- a/unstructured_inference/models/yolox.py
+++ b/unstructured_inference/models/yolox.py
@@ -51,7 +51,7 @@ class UnstructuredYoloXModel(UnstructuredModel):
         return self.image_processing(x)
 
     def initialize(self, model_path: str, label_map: dict):
-        self.model = onnxruntime.InferenceSession(model_path)
+        self.model = onnxruntime.InferenceSession(model_path,providers=['CPUExecutionProvider'])
         self.layout_classes = label_map
 
     def image_processing(

--- a/unstructured_inference/models/yolox.py
+++ b/unstructured_inference/models/yolox.py
@@ -51,7 +51,7 @@ class UnstructuredYoloXModel(UnstructuredModel):
         return self.image_processing(x)
 
     def initialize(self, model_path: str, label_map: dict):
-        self.model = onnxruntime.InferenceSession(model_path,providers=['CPUExecutionProvider'])
+        self.model = onnxruntime.InferenceSession(model_path, providers=["CPUExecutionProvider"])
         self.layout_classes = label_map
 
     def image_processing(


### PR DESCRIPTION
The multithreading problem doesn't appears to happen on M1 chip (as it does in x64 processors)
This PR just removes Pool from DocumentLayout.get_elements_from_layout.
