### PR TITLE
chore: remove tqdm output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.14-dev0
+
+* Suppressed processing progress bars
+
 ## 0.2.13
 
 * Add table processing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.2.14-dev0
+## 0.2.14
 
 * Suppressed processing progress bars
 

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.2.13"  # pragma: no cover
+__version__ = "0.2.14-dev0"  # pragma: no cover

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.2.14-dev0"  # pragma: no cover
+__version__ = "0.2.14"  # pragma: no cover

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 import os
 import re
 import tempfile
-from tqdm import tqdm
 from typing import List, Optional, Tuple, Union, BinaryIO
 import unicodedata
 
@@ -157,13 +156,12 @@ class PageLayout:
         # NOTE(robinson) - This orders the page from top to bottom. We'll need more
         # sophisticated ordering logic for more complicated layouts.
         layout.sort(key=lambda element: element.y1)
-        elements = []
-        for e in tqdm(layout):
-            elements.append(
-                get_element_from_block(
-                    e, self.image, self.layout, self.ocr_strategy, self.extract_tables
-                )
+        elements = [
+            get_element_from_block(
+                e, self.image, self.layout, self.ocr_strategy, self.extract_tables
             )
+            for e in layout
+        ]
         return elements
 
     def _get_image_array(self) -> Union[np.ndarray, None]:


### PR DESCRIPTION
Removes progress bar output while processing pdfs and image elements.