### PR TITLE
fix: convert to pixels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.15-dev0
+
+* Fix for text block detection
+
 ## 0.2.14
 
 * Suppressed processing progress bars

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.2.14"  # pragma: no cover
+__version__ = "0.2.15-dev0"  # pragma: no cover

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -363,12 +363,21 @@ def load_pdf(
         )
         word_objs = [
             TextRegion(
-                x1=word["x0"], y1=word["top"], x2=word["x1"], y2=word["bottom"], text=word["text"]
+                x1=word["x0"] * dpi / 72,
+                y1=word["top"] * dpi / 72,
+                x2=word["x1"] * dpi / 72,
+                y2=word["bottom"] * dpi / 72,
+                text=word["text"],
             )
             for word in plumber_words
         ]
         image_objs = [
-            ImageTextRegion(x1=image["x0"], y1=image["y0"], x2=image["x1"], y2=image["y1"])
+            ImageTextRegion(
+                x1=image["x0"] * dpi / 72,
+                y1=image["y0"] * dpi / 72,
+                x2=image["x1"] * dpi / 72,
+                y2=image["y1"] * dpi / 72,
+            )
             for image in page.images
         ]
         layout = word_objs + image_objs


### PR DESCRIPTION
Fixes a bug where coordinates in point-coordinates were not being converted to pixel-coordinates in agreement with the specified DPI.

#### Testing:
Parsing `layout-parser-fast.pdf` Should properly extract the text from the title block.