### PR TITLE
fix: make paddleocr install optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.3.1
 
 * Pin protobuf version to avoid errors
+* Make paddleocr an extra again
 
 ## 0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.1
+
+* Pin protobuf version to avoid errors
+
 ## 0.3.0
 
 * Fix for text block detection

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -115,10 +115,8 @@ pillow==9.4.0
     #   torchvision
 portalocker==2.7.0
     # via iopath
-protobuf==3.20.3
-    # via
-    #   onnxruntime
-    #   unstructured-inference (setup.py)
+protobuf==4.22.1
+    # via onnxruntime
 pycocotools==2.0.6
     # via effdet
 pycparser==2.21

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -115,8 +115,10 @@ pillow==9.4.0
     #   torchvision
 portalocker==2.7.0
     # via iopath
-protobuf==4.22.1
-    # via onnxruntime
+protobuf==3.20.3
+    # via
+    #   onnxruntime
+    #   unstructured-inference (setup.py)
 pycocotools==2.0.6
     # via effdet
 pycparser==2.21

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -67,7 +67,7 @@ ipykernel==6.22.0
     #   nbclassic
     #   notebook
     #   qtconsole
-ipython==8.11.0
+ipython==8.12.0
     # via
     #   -r requirements/dev.in
     #   ipykernel
@@ -143,7 +143,7 @@ matplotlib-inline==0.1.6
     #   ipython
 mistune==2.0.5
     # via nbconvert
-nbclassic==0.5.3
+nbclassic==0.5.4
     # via notebook
 nbclient==0.7.2
     # via nbconvert
@@ -304,6 +304,8 @@ traitlets==5.9.0
     #   nbformat
     #   notebook
     #   qtconsole
+typing-extensions==4.5.0
+    # via ipython
 uri-template==1.2.0
     # via jsonschema
 wcwidth==0.2.6

--- a/setup.py
+++ b/setup.py
@@ -60,5 +60,6 @@ setup(
         "onnxruntime",
         "transformers",
         'unstructured.PaddleOCR ; platform_machine=="x86_64"',
+        "protobuf==3.20.*",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,8 @@ setup(
         "onnxruntime",
         "transformers",
         'unstructured.PaddleOCR ; platform_machine=="x86_64"',
+        # NOTE(alan): protobuf is required by onnxruntime, and causes errors when the latest version
+        # is used in conjunction with certain other libraries (tensorboard/flow for example).
         "protobuf==3.20.*",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -59,9 +59,22 @@ setup(
         "opencv-python==4.6.0.66",
         "onnxruntime",
         "transformers",
-        'unstructured.PaddleOCR ; platform_machine=="x86_64"',
-        # NOTE(alan): protobuf is required by onnxruntime, and causes errors when the latest version
-        # is used in conjunction with certain other libraries (tensorboard/flow for example).
-        "protobuf==3.20.*",
     ],
+    extras_require={
+        "tables": [
+            'unstructured.PaddleOCR ; platform_machine=="x86_64"',
+            # NOTE(crag): workaround issue for error output below
+            # ERROR test_unstructured/partition/test_common.py - TypeError: Descriptors cannot not
+            # be created directly.
+            # If this call came from a _pb2.py file, your generated code is out of date and must be
+            # regenerated with protoc >= 3.19.0.
+            # If you cannot immediately regenerate your protos, some other possible workarounds are:
+            #  1. Downgrade the protobuf package to 3.20.x or lower.
+            #  2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python
+            #     parsing and will be much slower).
+            "protobuf<3.21",
+            # NOTE(alan): Pin to get around error: undefined symbol: _dl_sym, version GLIBC_PRIVATE
+            "paddlepaddle>=2.4",
+        ]
+    },
 )

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.3.0"  # pragma: no cover
+__version__ = "0.3.1"  # pragma: no cover

--- a/unstructured_inference/models/paddle_ocr.py
+++ b/unstructured_inference/models/paddle_ocr.py
@@ -1,10 +1,10 @@
-from unstructured_paddleocr import PaddleOCR
-
-paddle_ocr: PaddleOCR = None
+paddle_ocr = None  # type: ignore
 
 
 def load_agent():
     """Loads the PaddleOCR agent as a global variable to ensure that we only load it once."""
+
+    from unstructured_paddleocr import PaddleOCR
 
     global paddle_ocr
     paddle_ocr = PaddleOCR(use_angle_cls=True, lang="en", mkl_dnn=True, show_log=False)


### PR DESCRIPTION
Made `paddleocr` optional again, to avoid issues with `unstructured` docker image until we can resolve how to properly install `paddleocr` in Centos7.