### PR TITLE
feat: extend extract tables through interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.2
+
+* Allow extracting tables from higher level functions
+
 ## 0.3.1
 
 * Pin protobuf version to avoid errors

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.3.1"  # pragma: no cover
+__version__ = "0.3.2"  # pragma: no cover

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -170,6 +170,15 @@ class PageLayout:
             self.image_array = np.array(self.image)
         return self.image_array
 
+    def annotate(self) -> Image.Image:
+        """Returns image annotated with bounding boxes for the elements."""
+        ann_img = self.image.copy()
+        draw_image = ImageDraw.ImageDraw(ann_img)
+        for el in self.elements:
+            box = (el.x1, el.y1, el.x2, el.y2)
+            draw_image = draw_image.rectangle(box, outline="red")
+        return ann_img
+
     @classmethod
     def from_image(
         cls,

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -8,7 +8,7 @@ import unicodedata
 import numpy as np
 import pdfplumber
 import pdf2image
-from PIL import Image, ImageDraw
+from PIL import Image
 
 from unstructured_inference.inference.elements import TextRegion, ImageTextRegion, LayoutElement
 from unstructured_inference.logger import logger
@@ -169,15 +169,6 @@ class PageLayout:
         if self.image_array is None:
             self.image_array = np.array(self.image)
         return self.image_array
-
-    def annotate(self) -> Image.Image:
-        """Returns image annotated with bounding boxes for the elements."""
-        ann_img = self.image.copy()
-        draw_image = ImageDraw.ImageDraw(ann_img)
-        for el in self.elements:
-            box = (el.x1, el.y1, el.x2, el.y2)
-            draw_image = draw_image.rectangle(box, outline="red")
-        return ann_img
 
     @classmethod
     def from_image(

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -8,7 +8,7 @@ import unicodedata
 import numpy as np
 import pdfplumber
 import pdf2image
-from PIL import Image
+from PIL import Image, ImageDraw
 
 from unstructured_inference.inference.elements import TextRegion, ImageTextRegion, LayoutElement
 from unstructured_inference.logger import logger
@@ -115,7 +115,7 @@ class PageLayout:
     def __init__(
         self,
         number: int,
-        image: Image,
+        image: Image.Image,
         layout: Optional[List[TextRegion]],
         model: Optional[UnstructuredModel] = None,
         ocr_strategy: str = "auto",
@@ -211,6 +211,7 @@ def process_data_with_model(
     is_image: bool = False,
     ocr_strategy: str = "auto",
     fixed_layouts: Optional[List[Optional[List[TextRegion]]]] = None,
+    extract_tables: bool = False,
 ) -> DocumentLayout:
     """Processes pdf file in the form of a file handler (supporting a read method) into a
     DocumentLayout by using a model identified by model_name."""
@@ -222,6 +223,7 @@ def process_data_with_model(
             is_image=is_image,
             ocr_strategy=ocr_strategy,
             fixed_layouts=fixed_layouts,
+            extract_tables=extract_tables,
         )
 
     return layout
@@ -233,15 +235,22 @@ def process_file_with_model(
     is_image: bool = False,
     ocr_strategy: str = "auto",
     fixed_layouts: Optional[List[Optional[List[TextRegion]]]] = None,
+    extract_tables: bool = False,
 ) -> DocumentLayout:
     """Processes pdf file with name filename into a DocumentLayout by using a model identified by
     model_name."""
     model = get_model(model_name)
     layout = (
-        DocumentLayout.from_image_file(filename, model=model, ocr_strategy=ocr_strategy)
+        DocumentLayout.from_image_file(
+            filename, model=model, ocr_strategy=ocr_strategy, extract_tables=extract_tables
+        )
         if is_image
         else DocumentLayout.from_file(
-            filename, model=model, ocr_strategy=ocr_strategy, fixed_layouts=fixed_layouts
+            filename,
+            model=model,
+            ocr_strategy=ocr_strategy,
+            fixed_layouts=fixed_layouts,
+            extract_tables=extract_tables,
         )
     )
     return layout


### PR DESCRIPTION
Allows `extract_tables` parameter to be passed from higher level functions `process_file_with_model` and `process_data_with_model`.

#### Testing:
Run:
```python
from unstructured_inference.inference.layout import process_file_with_model
process_file_with_model("sample-docs/loremipsum.pdf", model_name="yolox", extract_tables=False)
```
Should generate no errors.