### PR TITLE
fix: image location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 0.3.3-dev1
+## 0.3.3-dev2
 
+* Fixed embedded image coordinates being interpreted differently than embedded text coordinates
 * Update to how dependencies are being handled
 * Update detectron2 version
 

--- a/test_unstructured_inference/inference/test_layout.py
+++ b/test_unstructured_inference/inference/test_layout.py
@@ -400,3 +400,13 @@ def test_load_pdf_with_images():
     layouts, _ = layout.load_pdf("sample-docs/loremipsum-flat.pdf")
     first_page_layout = layouts[0]
     assert any(isinstance(obj, layout.ImageTextRegion) for obj in first_page_layout)
+
+
+def test_load_pdf_image_placement():
+    layouts, images = layout.load_pdf("sample-docs/layout-parser-paper.pdf")
+    page_layout = layouts[5]
+    image_regions = [region for region in page_layout if isinstance(region, layout.ImageTextRegion)]
+    image_region = image_regions[0]
+    # Image is in top half of the page, so that should be reflected in the pixel coordinates
+    assert image_region.y1 < images[5].height / 2
+    assert image_region.y2 < images[5].height / 2

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.3.3-dev1"  # pragma: no cover
+__version__ = "0.3.3-dev2"  # pragma: no cover

--- a/unstructured_inference/inference/elements.py
+++ b/unstructured_inference/inference/elements.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Union
 
 from layoutparser.elements.layout import TextBlock
 
 
 @dataclass
 class Rectangle:
-    x1: int
-    y1: int
-    x2: int
-    y2: int
+    x1: Union[int, float]
+    y1: Union[int, float]
+    x2: Union[int, float]
+    y2: Union[int, float]
 
     def pad(self, padding: int):
         """Increases (or decreases, if padding is negative) the size of the rectangle by extending

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -383,9 +383,9 @@ def load_pdf(
         image_objs = [
             ImageTextRegion(
                 x1=image["x0"] * dpi / 72,
-                y1=image["y0"] * dpi / 72,
+                y1=image["top"] * dpi / 72,
                 x2=image["x1"] * dpi / 72,
-                y2=image["y1"] * dpi / 72,
+                y2=image["bottom"] * dpi / 72,
             )
             for image in page.images
         ]


### PR DESCRIPTION
Fixed bug where wrong location keys were being used to vertically locate image objects, causing the images' vertical coordinates to be given in terms of distance from the bottom of the document while text elements had vertical coordinates in terms of distance from the top of the document.

Added test that fails before change, passes after change.

#### Testing:

Ensure test `test_load_pdf_image_placement` fails on `main` branch, passes CI.