### PR TITLE
refactor: partition in elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.3-dev3
+## 0.4.0
 
 * Added logic to partition granular elements (words, characters) by proximity
 * Text extraction is now delegated to text regions rather than being handled centrally

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
-## 0.3.3-dev2
+## 0.3.3-dev3
 
+* Added logic to partition granular elements (words, characters) by proximity
+* Text extraction is now delegated to text regions rather than being handled centrally
 * Fixed embedded image coordinates being interpreted differently than embedded text coordinates
 * Update to how dependencies are being handled
 * Update detectron2 version

--- a/test_unstructured_inference/test_elements.py
+++ b/test_unstructured_inference/test_elements.py
@@ -1,0 +1,44 @@
+from random import randint
+from unstructured_inference.inference import elements
+
+rect1 = elements.Rectangle(0, 0, 10, 10)
+rect2 = elements.Rectangle(20, 20, 30, 30)
+rect3 = elements.Rectangle(2, 2, 30, 30)
+
+
+def test_intersection():
+    assert rect1.intersection(rect3) == elements.Rectangle(2, 2, 10, 10)
+
+
+def intersect_brute(rect1, rect2):
+    return any(
+        (rect2.x1 <= x <= rect2.x2) and (rect2.y1 <= y <= rect2.y2)
+        for x in range(rect1.x1, rect1.x2 + 1)
+        for y in range(rect1.y1, rect1.y2 + 1)
+    )
+
+
+def rand_rect():
+    x1 = randint(0, 20)
+    y1 = randint(0, 20)
+    return elements.Rectangle(x1, y1, x1 + 10, y1 + 10)
+
+
+def rand_big_rect():
+    x1 = randint(0, 10)
+    y1 = randint(0, 10)
+    return elements.Rectangle(x1, y1, x1 + 20, y1 + 20)
+
+
+def test_intersects_overlap():
+    for _ in range(1000):
+        rect1 = rand_rect()
+        rect2 = rand_rect()
+        assert intersect_brute(rect1, rect2) == rect1.intersects(rect2) == rect2.intersects(rect1)
+
+
+def test_intersects_subset():
+    for _ in range(1000):
+        rect1 = rand_rect()
+        rect2 = rand_big_rect()
+        assert intersect_brute(rect1, rect2) == rect1.intersects(rect2) == rect2.intersects(rect1)

--- a/test_unstructured_inference/test_elements.py
+++ b/test_unstructured_inference/test_elements.py
@@ -1,13 +1,6 @@
 from random import randint
 from unstructured_inference.inference import elements
-
-rect1 = elements.Rectangle(0, 0, 10, 10)
-rect2 = elements.Rectangle(20, 20, 30, 30)
-rect3 = elements.Rectangle(2, 2, 30, 30)
-
-
-def test_intersection():
-    assert rect1.intersection(rect3) == elements.Rectangle(2, 2, 10, 10)
+from unstructured_inference.inference.layout import load_pdf
 
 
 def intersect_brute(rect1, rect2):
@@ -18,16 +11,10 @@ def intersect_brute(rect1, rect2):
     )
 
 
-def rand_rect():
-    x1 = randint(0, 20)
-    y1 = randint(0, 20)
-    return elements.Rectangle(x1, y1, x1 + 10, y1 + 10)
-
-
-def rand_big_rect():
-    x1 = randint(0, 10)
-    y1 = randint(0, 10)
-    return elements.Rectangle(x1, y1, x1 + 20, y1 + 20)
+def rand_rect(size=10):
+    x1 = randint(0, 30 - size)
+    y1 = randint(0, 30 - size)
+    return elements.Rectangle(x1, y1, x1 + size, y1 + size)
 
 
 def test_intersects_overlap():
@@ -40,5 +27,58 @@ def test_intersects_overlap():
 def test_intersects_subset():
     for _ in range(1000):
         rect1 = rand_rect()
-        rect2 = rand_big_rect()
+        rect2 = rand_rect(20)
         assert intersect_brute(rect1, rect2) == rect1.intersects(rect2) == rect2.intersects(rect1)
+
+
+def test_intersection_of_lots_of_rects():
+    for _ in range(1000):
+        n_rects = 10
+        rects = [rand_rect(6) for _ in range(n_rects)]
+        intersection_mtx = elements.intersections(*rects)
+        for i in range(n_rects):
+            for j in range(n_rects):
+                assert (
+                    intersect_brute(rects[i], rects[j])
+                    == intersection_mtx[i, j]
+                    == intersection_mtx[j, i]
+                )
+
+
+def test_rectangle_width_height():
+    for _ in range(1000):
+        x1 = randint(0, 50)
+        x2 = randint(x1 + 1, 100)
+        y1 = randint(0, 50)
+        y2 = randint(y1 + 1, 100)
+        rect = elements.Rectangle(x1, y1, x2, y2)
+        assert rect.width == x2 - x1
+        assert rect.height == y2 - y1
+
+
+def test_minimal_containing_rect():
+    for _ in range(1000):
+        rect1 = rand_rect()
+        rect2 = rand_rect()
+        big_rect = elements.minimal_containing_region(rect1, rect2)
+        for decrease_attr in ["x1", "y1", "x2", "y2"]:
+            almost_as_big_rect = rand_rect()
+            mod = 1 if decrease_attr.endswith("1") else -1
+            for attr in ["x1", "y1", "x2", "y2"]:
+                if attr == decrease_attr:
+                    setattr(almost_as_big_rect, attr, getattr(big_rect, attr) + mod)
+                else:
+                    setattr(almost_as_big_rect, attr, getattr(big_rect, attr))
+            assert not rect1.is_in(almost_as_big_rect) or not rect2.is_in(almost_as_big_rect)
+
+        assert rect1.is_in(big_rect)
+        assert rect2.is_in(big_rect)
+
+
+def test_partition_groups_from_regions():
+    words, _ = load_pdf("sample-docs/layout-parser-paper.pdf")
+    groups = elements.partition_groups_from_regions(words[0])
+    assert len(groups) == 9
+    sorted_groups = sorted(groups, key=lambda group: group[0].y1)
+    text = "".join([el.text for el in sorted_groups[-1]])
+    assert text.startswith("Deep")

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.3.3-dev3"  # pragma: no cover
+__version__ = "0.4.0"  # pragma: no cover

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.3.3-dev2"  # pragma: no cover
+__version__ = "0.3.3-dev3"  # pragma: no cover

--- a/unstructured_inference/inference/elements.py
+++ b/unstructured_inference/inference/elements.py
@@ -12,7 +12,12 @@ from scipy.sparse.csgraph import connected_components
 from unstructured_inference.logger import logger
 from unstructured_inference.models import tesseract
 
+# When extending the boundaries of a PDF object for the purpose of determining which other elements
+# should be considered in the same text region, we use a relative distance based on some fraction of
+# the block height (typically character height). This is the fraction used for the horizontal
+# extension applied to the left and right sides.
 H_PADDING_COEF = 0.4
+# Same as above but the vertical extension.
 V_PADDING_COEF = 0.3
 
 

--- a/unstructured_inference/inference/elements.py
+++ b/unstructured_inference/inference/elements.py
@@ -1,9 +1,19 @@
 from __future__ import annotations
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Optional, Union
+import re
+from typing import Optional, Union, Sequence, List
+import unicodedata
 
-from layoutparser.elements.layout import TextBlock
+import numpy as np
+from PIL import Image
+from scipy.sparse.csgraph import connected_components
+
+from unstructured_inference.logger import logger
+from unstructured_inference.models import tesseract
+
+H_PADDING_COEF = 0.4
+V_PADDING_COEF = 0.3
 
 
 @dataclass
@@ -21,7 +31,7 @@ class Rectangle:
 
     def hpad(self, padding: Union[int, float]):
         """Increases (or decreases, if padding is negative) the size of the rectangle by extending
-        the boundary outward (resp. inward)."""
+        the left and right sides of the boundary outward (resp. inward)."""
         out_object = deepcopy(self)
         out_object.x1 -= padding
         out_object.x2 += padding
@@ -29,36 +39,31 @@ class Rectangle:
 
     def vpad(self, padding: Union[int, float]):
         """Increases (or decreases, if padding is negative) the size of the rectangle by extending
-        the boundary outward (resp. inward)."""
+        the top and bottom of the boundary outward (resp. inward)."""
         out_object = deepcopy(self)
         out_object.y1 -= padding
         out_object.y2 += padding
         return out_object
 
     @property
-    def width(self):
+    def width(self) -> Union[int, float]:
         """Width of rectangle"""
         return self.x2 - self.x1
 
     @property
-    def height(self):
+    def height(self) -> Union[int, float]:
         """Height of rectangle"""
         return self.y2 - self.y1
 
-    def is_disjoint(self, other: Rectangle):
+    def is_disjoint(self, other: Rectangle) -> bool:
         """Checks whether this rectangle is disjoint from another rectangle."""
-        return (
-            (self.x2 < other.x1)
-            or (self.x1 > other.x2)
-            or (self.y2 < other.y1)
-            or (self.y1 > other.y2)
-        )
+        return not self.intersects(other)
 
-    def intersects(self, other: Rectangle):
+    def intersects(self, other: Rectangle) -> bool:
         """Checks whether this rectangle intersects another rectangle."""
-        return not self.is_disjoint(other)
+        return intersections(self, other)[0, 1]
 
-    def is_in(self, other: Rectangle, error_margin: Optional[Union[int, float]] = None):
+    def is_in(self, other: Rectangle, error_margin: Optional[Union[int, float]] = None) -> bool:
         """Checks whether this rectangle is contained within another rectangle."""
         if error_margin is not None:
             padded_other = other.pad(error_margin)
@@ -79,48 +84,6 @@ class Rectangle:
         return ((self.x1, self.y1), (self.x1, self.y2), (self.x2, self.y2), (self.x2, self.y1))
 
 
-@dataclass
-class TextRegion(Rectangle):
-    text: Optional[str] = None
-
-    def __str__(self) -> str:
-        return str(self.text)
-
-
-class ImageTextRegion(TextRegion):
-    pass
-
-
-@dataclass
-class LayoutElement(TextRegion):
-    type: Optional[str] = None
-
-    def to_dict(self) -> dict:
-        """Converts the class instance to dictionary form."""
-        out_dict = {
-            "coordinates": self.coordinates,
-            "text": self.text,
-            "type": self.type,
-        }
-        return out_dict
-
-    @classmethod
-    def from_region(cls, region: Rectangle):
-        """Create LayoutElement from superclass."""
-        x1, y1, x2, y2 = region.x1, region.y1, region.x2, region.y2
-        text = region.text if hasattr(region, "text") else None
-        type = region.type if hasattr(region, "type") else None
-        return cls(x1, y1, x2, y2, text, type)
-
-    @classmethod
-    def from_lp_textblock(cls, textblock: TextBlock):
-        """Create LayoutElement from layoutparser TextBlock object."""
-        x1, y1, x2, y2 = textblock.coordinates
-        text = textblock.text
-        type = textblock.type
-        return cls(x1, y1, x2, y2, text, type)
-
-
 def minimal_containing_region(*regions: Rectangle) -> Rectangle:
     """Returns the smallest rectangular region that contains all regions passed"""
     x1 = min(region.x1 for region in regions)
@@ -137,3 +100,197 @@ def minimal_containing_region(*regions: Rectangle) -> Rectangle:
 
     cls = least_common_superclass(*regions)
     return cls(x1, y1, x2, y2)
+
+
+def partition_groups_from_regions(regions: Sequence[Rectangle]) -> List[List[Rectangle]]:
+    """Partitions regions into groups of regions based on proximity. Returns list of lists of
+    regions, each list corresponding with a group"""
+    padded_regions = [
+        r.vpad(r.height * V_PADDING_COEF).hpad(r.height * H_PADDING_COEF) for r in regions
+    ]
+
+    intersection_mtx = intersections(*padded_regions)
+
+    _, group_nums = connected_components(intersection_mtx)
+    groups: List[List[Rectangle]] = [[] for _ in range(max(group_nums) + 1)]
+    for region, group_num in zip(regions, group_nums):
+        groups[group_num].append(region)
+
+    return groups
+
+
+def intersections(*rects: Rectangle):
+    """Returns a square boolean matrix of intersections of an arbitrary number of rectangles, i.e.
+    the ijth entry of the matrix is True if and only if the ith Rectangle and jth Rectangle
+    intersect."""
+    coords = np.stack([[[r.x1, r.y1], [r.x2, r.y2]] for r in rects], axis=-1)
+
+    (x1s, y1s), (x2s, y2s) = coords
+
+    # Use broadcasting to get comparison matrices.
+    # For Rectangles r1 and r2, any of the following conditions makes the rectangles disjoint:
+    # r1.x1 > r2.x2
+    # r1.y1 > r2.y2
+    # r2.x1 > r1.x2
+    # r2.y1 > r1.y2
+    # Then we take the complement (~) of the disjointness matrix to get the intersection matrix.
+    intersections = ~(
+        (x1s[None] > x2s[..., None])
+        | (y1s[None] > y2s[..., None])
+        | (x1s[None] > x2s[..., None]).T
+        | (y1s[None] > y2s[..., None]).T
+    )
+
+    return intersections
+
+
+@dataclass
+class TextRegion(Rectangle):
+    text: Optional[str] = None
+
+    def __str__(self) -> str:
+        return str(self.text)
+
+    def extract_text(
+        self,
+        objects: Optional[List[TextRegion]],
+        image: Optional[Image.Image] = None,
+        extract_tables: bool = False,
+        ocr_strategy: str = "auto",
+    ) -> str:
+        """Extracts text contained in region."""
+        if self.text is not None:
+            # If block text is already populated, we'll assume it's correct
+            text = self.text
+        elif objects is not None:
+            text = aggregate_by_block(self, image, objects, ocr_strategy)
+        elif image is not None:
+            if ocr_strategy != "never":
+                # We don't have anything to go on but the image itself, so we use OCR
+                text = ocr(self, image)
+            else:
+                text = ""
+        else:
+            raise ValueError(
+                "Got arguments image and layout as None, at least one must be populated to use for "
+                "text extraction."
+            )
+        return text
+
+
+class EmbeddedTextRegion(TextRegion):
+    def extract_text(
+        self,
+        objects: Optional[List[TextRegion]],
+        image: Optional[Image.Image] = None,
+        extract_tables: bool = False,
+        ocr_strategy: str = "auto",
+    ) -> str:
+        """Extracts text contained in region."""
+        if self.text is None:
+            return ""
+        else:
+            return self.text
+
+
+class ImageTextRegion(TextRegion):
+    def extract_text(
+        self,
+        objects: Optional[List[TextRegion]],
+        image: Optional[Image.Image] = None,
+        extract_tables: bool = False,
+        ocr_strategy: str = "auto",
+    ) -> str:
+        """Extracts text contained in region."""
+        if self.text is None:
+            if ocr_strategy == "never" or image is None:
+                return ""
+            else:
+                return ocr(self, image)
+        else:
+            return super().extract_text(objects, image, extract_tables, ocr_strategy)
+
+
+def ocr(text_block: TextRegion, image: Image.Image) -> str:
+    """Runs a cropped text block image through and OCR agent."""
+    logger.debug("Running OCR on text block ...")
+    tesseract.load_agent()
+    padded_block = text_block.pad(12)
+    cropped_image = image.crop((padded_block.x1, padded_block.y1, padded_block.x2, padded_block.y2))
+    return tesseract.ocr_agent.detect(cropped_image)
+
+
+def needs_ocr(
+    region: TextRegion,
+    pdf_objects: List[TextRegion],
+    ocr_strategy: str,
+) -> bool:
+    """Logic to determine whether ocr is needed to extract text from given region."""
+    if ocr_strategy == "force":
+        return True
+    elif ocr_strategy == "auto":
+        image_objects = [obj for obj in pdf_objects if isinstance(obj, ImageTextRegion)]
+        word_objects = [obj for obj in pdf_objects if isinstance(obj, EmbeddedTextRegion)]
+        # If any image object overlaps with the region of interest, we have hope of getting some
+        # text from OCR. Otherwise, there's nothing there to find, no need to waste our time with
+        # OCR.
+        image_intersects = any(region.intersects(img_obj) for img_obj in image_objects)
+        if region.text is None:
+            # If the region has no text check if any images overlap with the region that might
+            # contain text.
+            if any(obj.is_in(region) and obj.text is not None for obj in word_objects):
+                # If there are word objects in the region, we defer to that rather than OCR
+                return False
+            else:
+                return image_intersects
+        elif cid_ratio(region.text) > 0.5:
+            # If the region has text, we should only have to OCR if too much of the text is
+            # uninterpretable.
+            return True
+        else:
+            return False
+    else:
+        return False
+
+
+def aggregate_by_block(
+    text_region: TextRegion,
+    image: Optional[Image.Image],
+    pdf_objects: List[TextRegion],
+    ocr_strategy: str = "auto",
+) -> str:
+    """Extracts the text aggregated from the elements of the given layout that lie within the given
+    block."""
+    if image is not None and needs_ocr(text_region, pdf_objects, ocr_strategy):
+        text = ocr(text_region, image)
+    else:
+        filtered_blocks = [obj for obj in pdf_objects if obj.is_in(text_region, error_margin=5)]
+        for little_block in filtered_blocks:
+            if image is not None and needs_ocr(little_block, pdf_objects, ocr_strategy):
+                little_block.text = ocr(little_block, image)
+        text = " ".join([x.text for x in filtered_blocks if x.text])
+    text = remove_control_characters(text)
+    return text
+
+
+def cid_ratio(text: str) -> float:
+    """Gets ratio of unknown 'cid' characters extracted from text to all characters."""
+    if not is_cid_present(text):
+        return 0.0
+    cid_pattern = r"\(cid\:(\d+)\)"
+    unmatched, n_cid = re.subn(cid_pattern, "", text)
+    total = n_cid + len(unmatched)
+    return n_cid / total
+
+
+def is_cid_present(text: str) -> bool:
+    """Checks if a cid code is present in a text selection."""
+    if len(text) < len("(cid:x)"):
+        return False
+    return text.find("(cid:") != -1
+
+
+def remove_control_characters(text: str) -> str:
+    """Removes control characters from text."""
+    out_text = "".join(c for c in text if unicodedata.category(c)[0] != "C")
+    return out_text

--- a/unstructured_inference/inference/layoutelement.py
+++ b/unstructured_inference/inference/layoutelement.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import List, Optional
+
+from layoutparser.elements.layout import TextBlock
+from PIL import Image
+
+from unstructured_inference.inference.elements import Rectangle, TextRegion
+from unstructured_inference.models import tables
+
+
+@dataclass
+class LayoutElement(TextRegion):
+    type: Optional[str] = None
+
+    def extract_text(
+        self,
+        objects: Optional[List[TextRegion]],
+        image: Optional[Image.Image] = None,
+        extract_tables: bool = False,
+        ocr_strategy: str = "auto",
+    ):
+        """Extracts text contained in region"""
+        if self.text is not None:
+            # If block text is already populated, we'll assume it's correct
+            text = self.text
+        elif extract_tables and isinstance(self, LayoutElement) and self.type == "Table":
+            text = interprete_table_block(self, image)
+        else:
+            text = super().extract_text(
+                objects=objects,
+                image=image,
+                extract_tables=extract_tables,
+                ocr_strategy=ocr_strategy,
+            )
+        return text
+
+    def to_dict(self) -> dict:
+        """Converts the class instance to dictionary form."""
+        out_dict = {
+            "coordinates": self.coordinates,
+            "text": self.text,
+            "type": self.type,
+        }
+        return out_dict
+
+    @classmethod
+    def from_region(cls, region: Rectangle):
+        """Create LayoutElement from superclass."""
+        x1, y1, x2, y2 = region.x1, region.y1, region.x2, region.y2
+        text = region.text if hasattr(region, "text") else None
+        type = region.type if hasattr(region, "type") else None
+        return cls(x1, y1, x2, y2, text, type)
+
+    @classmethod
+    def from_lp_textblock(cls, textblock: TextBlock):
+        """Create LayoutElement from layoutparser TextBlock object."""
+        x1, y1, x2, y2 = textblock.coordinates
+        text = textblock.text
+        type = textblock.type
+        return cls(x1, y1, x2, y2, text, type)
+
+
+def interprete_table_block(text_block: TextRegion, image: Image.Image) -> str:
+    """Extract the contents of a table."""
+    tables.load_agent()
+    if tables.tables_agent is None:
+        raise RuntimeError("Unable to load table extraction agent.")
+    padded_block = text_block.pad(12)
+    cropped_image = image.crop((padded_block.x1, padded_block.y1, padded_block.x2, padded_block.y2))
+    return tables.tables_agent.predict(cropped_image)

--- a/unstructured_inference/models/detectron2.py
+++ b/unstructured_inference/models/detectron2.py
@@ -10,7 +10,7 @@ from PIL import Image
 from huggingface_hub import hf_hub_download
 
 from unstructured_inference.logger import logger
-from unstructured_inference.inference.elements import LayoutElement
+from unstructured_inference.inference.layoutelement import LayoutElement
 from unstructured_inference.models.unstructuredmodel import UnstructuredModel
 from unstructured_inference.utils import LazyDict, LazyEvaluateInfo
 

--- a/unstructured_inference/models/yolox.py
+++ b/unstructured_inference/models/yolox.py
@@ -10,7 +10,7 @@ import numpy as np
 import onnxruntime
 from typing import List
 
-from unstructured_inference.inference.elements import LayoutElement
+from unstructured_inference.inference.layoutelement import LayoutElement
 from unstructured_inference.models.unstructuredmodel import UnstructuredModel
 from unstructured_inference.visualize import draw_bounding_boxes
 from unstructured_inference.utils import LazyDict, LazyEvaluateInfo


### PR DESCRIPTION
Added the capability to partition granular-scale elements that have been identified (words, characters) by proximity using the word/character height as a reference. In many cases this does a good job of grouping text blocks. Also moved logic for extracting text from a region into the region itself, so in the future different logic can be used for embedded text and images.

#### Testing:

In a jupyter notebook, try the following code:

```python
from unstructured_inference.inference.layout import load_pdf
from unstructured_inference.inference.elements import partition_groups_from_regions

words, images = load_pdf('sample-docs/layout-parser-paper.pdf')

colors = ["red", "green", "blue", "cyan", "yellow", "magenta", "purple"] * 8

from PIL.ImageDraw import ImageDraw
def annotate_regions(rects, image, color):
    img = image.copy()
    draw = ImageDraw(img)
    for rect in rects:
        x1, y1, x2, y2 = rect.x1, rect.y1, rect.x2, rect.y2
        draw.rectangle(((x1, y1), (x2, y2)), outline=color)
    return img

def annotate_groups(groups, image):
    out_image = image.copy()
    for i, group in enumerate(groups):
        out_image = annotate_regions(group, out_image, colors[i])
    return out_image
 
groups = partition_groups_from_regions(words[0])
annotate_groups(groups, images[0])
```
The output should be the first page of the layout parser paper with color-coded groupings of the words in the page, representing the partition produced.