### PR TITLE
feat: add ability to pass languages to OCR agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.1-dev0
+
+* Added the ability to pass `ocr_languages` to the OCR agent for users who need
+  non-English language packs.
+
 ## 0.4.0
 
 * Added logic to partition granular elements (words, characters) by proximity

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.4.1-dev0
+## 0.4.1
 
 * Added the ability to pass `ocr_languages` to the OCR agent for users who need
   non-English language packs.

--- a/test_unstructured_inference/inference/test_layout.py
+++ b/test_unstructured_inference/inference/test_layout.py
@@ -44,7 +44,7 @@ def test_ocr(monkeypatch):
         def detect(self, *args):
             return mock_text
 
-    monkeypatch.setattr(tesseract, "ocr_agent", MockOCRAgent)
+    monkeypatch.setattr(tesseract, "ocr_agents", {"eng": MockOCRAgent})
     monkeypatch.setattr(tesseract, "is_pytesseract_available", lambda *args: True)
 
     image = Image.fromarray(np.random.randint(12, 24, (40, 40)), mode="RGB")
@@ -96,7 +96,7 @@ def test_get_page_elements_with_ocr(monkeypatch):
     doc_layout = [text_block, image_block]
 
     monkeypatch.setattr(detectron2, "is_detectron2_available", lambda *args: True)
-    monkeypatch.setattr(elements, "ocr", lambda *args: "An Even Catchier Title")
+    monkeypatch.setattr(elements, "ocr", lambda *args, **kwargs: "An Even Catchier Title")
 
     image = Image.fromarray(np.random.randint(12, 14, size=(40, 10, 3)), mode="RGB")
     page = layout.PageLayout(
@@ -187,11 +187,19 @@ class MockEmbeddedTextRegion(layout.EmbeddedTextRegion):
 
 
 class MockPageLayout(layout.PageLayout):
-    def __init__(self, layout=None, model=None, ocr_strategy="auto", extract_tables=False):
+    def __init__(
+        self,
+        layout=None,
+        model=None,
+        ocr_strategy="auto",
+        ocr_languages="eng",
+        extract_tables=False,
+    ):
         self.image = None
         self.layout = layout
         self.model = model
         self.ocr_strategy = ocr_strategy
+        self.ocr_languages = ocr_languages
         self.extract_tables = extract_tables
 
     def ocr(self, text_block: MockEmbeddedTextRegion):

--- a/test_unstructured_inference/models/test_tesseract.py
+++ b/test_unstructured_inference/models/test_tesseract.py
@@ -11,12 +11,12 @@ class MockTesseractAgent:
 
 def test_load_agent(monkeypatch):
     monkeypatch.setattr(tesseract, "TesseractAgent", MockTesseractAgent)
-    monkeypatch.setattr(tesseract, "ocr_agent", None)
+    monkeypatch.setattr(tesseract, "ocr_agents", {})
 
     with patch.object(tesseract, "is_pytesseract_available", return_value=True):
-        tesseract.load_agent()
+        tesseract.load_agent(languages="eng+swe")
 
-    assert isinstance(tesseract.ocr_agent, MockTesseractAgent)
+    assert isinstance(tesseract.ocr_agents["eng+swe"], MockTesseractAgent)
 
 
 def test_load_agent_raises_when_not_available():

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.4.1-dev0"  # pragma: no cover
+__version__ = "0.4.1"  # pragma: no cover

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.4.0"  # pragma: no cover
+__version__ = "0.4.1-dev0"  # pragma: no cover

--- a/unstructured_inference/inference/elements.py
+++ b/unstructured_inference/inference/elements.py
@@ -279,7 +279,7 @@ def aggregate_by_block(
         filtered_blocks = [obj for obj in pdf_objects if obj.is_in(text_region, error_margin=5)]
         for little_block in filtered_blocks:
             if image is not None and needs_ocr(little_block, pdf_objects, ocr_strategy):
-                little_block.text = ocr(little_block, image)
+                little_block.text = ocr(little_block, image, languages=ocr_languages)
         text = " ".join([x.text for x in filtered_blocks if x.text])
     text = remove_control_characters(text)
     return text

--- a/unstructured_inference/inference/elements.py
+++ b/unstructured_inference/inference/elements.py
@@ -225,7 +225,10 @@ def ocr(text_block: TextRegion, image: Image.Image, languages: str = "eng") -> s
     tesseract.load_agent(languages=languages)
     padded_block = text_block.pad(12)
     cropped_image = image.crop((padded_block.x1, padded_block.y1, padded_block.x2, padded_block.y2))
-    return tesseract.ocr_agent.detect(cropped_image)
+    agent = tesseract.ocr_agents.get(languages)
+    if agent is None:
+        raise RuntimeError("OCR agent is not loaded for {languages}.")
+    return agent.detect(cropped_image)
 
 
 def needs_ocr(

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -55,6 +55,7 @@ class DocumentLayout:
         model: Optional[UnstructuredModel] = None,
         fixed_layouts: Optional[List[Optional[List[TextRegion]]]] = None,
         ocr_strategy: str = "auto",
+        ocr_languages: str = "eng",
         extract_tables: bool = False,
     ) -> DocumentLayout:
         """Creates a DocumentLayout from a pdf file."""
@@ -75,6 +76,7 @@ class DocumentLayout:
                 model=model,
                 layout=layout,
                 ocr_strategy=ocr_strategy,
+                ocr_languages=ocr_languages,
                 fixed_layout=fixed_layout,
                 extract_tables=extract_tables,
             )
@@ -87,6 +89,7 @@ class DocumentLayout:
         filename: str,
         model: Optional[UnstructuredModel] = None,
         ocr_strategy: str = "auto",
+        ocr_languages: str = "eng",
         fixed_layout: Optional[List[TextRegion]] = None,
         extract_tables: bool = False,
     ) -> DocumentLayout:
@@ -104,6 +107,7 @@ class DocumentLayout:
             model=model,
             layout=None,
             ocr_strategy=ocr_strategy,
+            ocr_languages=ocr_languages,
             fixed_layout=fixed_layout,
             extract_tables=extract_tables,
         )
@@ -120,6 +124,7 @@ class PageLayout:
         layout: Optional[List[TextRegion]],
         model: Optional[UnstructuredModel] = None,
         ocr_strategy: str = "auto",
+        ocr_languages: str = "eng",
         extract_tables: bool = False,
     ):
         self.image = image
@@ -131,6 +136,7 @@ class PageLayout:
         if ocr_strategy not in VALID_OCR_STRATEGIES:
             raise ValueError(f"ocr_strategy must be one of {VALID_OCR_STRATEGIES}.")
         self.ocr_strategy = ocr_strategy
+        self.ocr_languages = ocr_languages
         self.extract_tables = extract_tables
 
     def __str__(self) -> str:
@@ -159,7 +165,12 @@ class PageLayout:
         layout.sort(key=lambda element: element.y1)
         elements = [
             get_element_from_block(
-                e, self.image, self.layout, self.ocr_strategy, self.extract_tables
+                block=e,
+                image=self.image,
+                pdf_objects=self.layout,
+                ocr_strategy=self.ocr_strategy,
+                ocr_languages=self.ocr_languages,
+                extract_tables=self.extract_tables,
             )
             for e in layout
         ]
@@ -178,6 +189,7 @@ class PageLayout:
         model: Optional[UnstructuredModel] = None,
         layout: Optional[List[TextRegion]] = None,
         ocr_strategy: str = "auto",
+        ocr_languages: str = "eng",
         extract_tables: bool = False,
         fixed_layout: Optional[List[TextRegion]] = None,
     ):
@@ -188,6 +200,7 @@ class PageLayout:
             layout=layout,
             model=model,
             ocr_strategy=ocr_strategy,
+            ocr_languages=ocr_languages,
             extract_tables=extract_tables,
         )
         if fixed_layout is None:
@@ -202,6 +215,7 @@ def process_data_with_model(
     model_name: Optional[str],
     is_image: bool = False,
     ocr_strategy: str = "auto",
+    ocr_languages: str = "eng",
     fixed_layouts: Optional[List[Optional[List[TextRegion]]]] = None,
     extract_tables: bool = False,
 ) -> DocumentLayout:
@@ -214,6 +228,7 @@ def process_data_with_model(
             model_name,
             is_image=is_image,
             ocr_strategy=ocr_strategy,
+            ocr_languages=ocr_languages,
             fixed_layouts=fixed_layouts,
             extract_tables=extract_tables,
         )
@@ -226,6 +241,7 @@ def process_file_with_model(
     model_name: Optional[str],
     is_image: bool = False,
     ocr_strategy: str = "auto",
+    ocr_languages: str = "eng",
     fixed_layouts: Optional[List[Optional[List[TextRegion]]]] = None,
     extract_tables: bool = False,
 ) -> DocumentLayout:
@@ -234,13 +250,18 @@ def process_file_with_model(
     model = get_model(model_name)
     layout = (
         DocumentLayout.from_image_file(
-            filename, model=model, ocr_strategy=ocr_strategy, extract_tables=extract_tables
+            filename,
+            model=model,
+            ocr_strategy=ocr_strategy,
+            ocr_languages=ocr_languages,
+            extract_tables=extract_tables,
         )
         if is_image
         else DocumentLayout.from_file(
             filename,
             model=model,
             ocr_strategy=ocr_strategy,
+            ocr_languages=ocr_languages,
             fixed_layouts=fixed_layouts,
             extract_tables=extract_tables,
         )
@@ -253,13 +274,18 @@ def get_element_from_block(
     image: Optional[Image.Image] = None,
     pdf_objects: Optional[List[TextRegion]] = None,
     ocr_strategy: str = "auto",
+    ocr_languages: str = "eng",
     extract_tables: bool = False,
 ) -> LayoutElement:
     """Creates a LayoutElement from a given layout or image by finding all the text that lies within
     a given block."""
     element = LayoutElement.from_region(block)
     element.text = block.extract_text(
-        objects=pdf_objects, image=image, extract_tables=extract_tables, ocr_strategy=ocr_strategy
+        objects=pdf_objects,
+        image=image,
+        extract_tables=extract_tables,
+        ocr_strategy=ocr_strategy,
+        ocr_languages=ocr_languages,
     )
     return element
 

--- a/unstructured_inference/inference/layoutelement.py
+++ b/unstructured_inference/inference/layoutelement.py
@@ -19,6 +19,7 @@ class LayoutElement(TextRegion):
         image: Optional[Image.Image] = None,
         extract_tables: bool = False,
         ocr_strategy: str = "auto",
+        ocr_languages: str = "eng",
     ):
         """Extracts text contained in region"""
         if self.text is not None:
@@ -32,6 +33,7 @@ class LayoutElement(TextRegion):
                 image=image,
                 extract_tables=extract_tables,
                 ocr_strategy=ocr_strategy,
+                ocr_languages=ocr_languages,
             )
         return text
 

--- a/unstructured_inference/models/tesseract.py
+++ b/unstructured_inference/models/tesseract.py
@@ -1,8 +1,10 @@
+from typing import Dict
+
 from layoutparser.ocr.tesseract_agent import is_pytesseract_available, TesseractAgent
 
 from unstructured_inference.logger import logger
 
-ocr_agent: TesseractAgent = None
+ocr_agents: Dict[str, TesseractAgent] = {}
 
 
 def load_agent(languages: str = "eng"):
@@ -14,7 +16,7 @@ def load_agent(languages: str = "eng"):
         The languages to use for the Tesseract agent. To use a langauge, you'll first need
         to isntall the appropriate Tesseract language pack.
     """
-    global ocr_agent
+    global ocr_agents
 
     if not is_pytesseract_available():
         raise ImportError(
@@ -22,6 +24,6 @@ def load_agent(languages: str = "eng"):
             "    >>> sudo apt install -y tesseract-ocr"
         )
 
-    if ocr_agent is None:
-        logger.info("Loading the Tesseract OCR agent ...")
-        ocr_agent = TesseractAgent(languages=languages)
+    if languages not in ocr_agents:
+        logger.info(f"Loading the Tesseract OCR agent for {languages} ...")
+        ocr_agents[languages] = TesseractAgent(languages=languages)

--- a/unstructured_inference/models/tesseract.py
+++ b/unstructured_inference/models/tesseract.py
@@ -5,8 +5,15 @@ from unstructured_inference.logger import logger
 ocr_agent: TesseractAgent = None
 
 
-def load_agent():
-    """Loads the Tesseract OCR agent as a global variable to ensure that we only load it once."""
+def load_agent(languages: str = "eng"):
+    """Loads the Tesseract OCR agent as a global variable to ensure that we only load it once.
+
+    Parameters
+    ----------
+    languages
+        The languages to use for the Tesseract agent. To use a langauge, you'll first need
+        to isntall the appropriate Tesseract language pack.
+    """
     global ocr_agent
 
     if not is_pytesseract_available():
@@ -17,4 +24,4 @@ def load_agent():
 
     if ocr_agent is None:
         logger.info("Loading the Tesseract OCR agent ...")
-        ocr_agent = TesseractAgent(languages="eng")
+        ocr_agent = TesseractAgent(languages=languages)


### PR DESCRIPTION
### Summary

Related to [`unstructured`#458](https://github.com/Unstructured-IO/unstructured/issues/458). Adds an `ocr_languages` kwarg to enable users to call OCR with non-English language packs.

### Testing

```python
from unstructured_inference.inference.layout import DocumentLayout

layout = DocumentLayout.from_file("sample-docs/loremipsum.pdf", ocr_languages="eng+swe")
print(layout.pages[0].elements)
```