### PR TITLE
chore: move to release version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.4
+
+* Fixed patches not being a package.
+
 ## 0.4.3
 
 * Patch pdfminer.six to fix parsing bug

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.4.3"  # pragma: no cover
+__version__ = "0.4.4"  # pragma: no cover


### PR DESCRIPTION
Move to release version to release the hotfix [here](https://github.com/Unstructured-IO/unstructured-inference/pull/100).