### PR TITLE
fix: pip-compile test before dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,8 @@ pip-compile:
 	# the detectron2 repo itself. If detectron2 is in the requirements.txt file, an order of
 	# operations issue related to the torch library causes the install to fail
 	sed 's/^detectron2 @/# detectron2 @/g' requirements/base.txt
-	pip-compile --upgrade requirements/dev.in
 	pip-compile --upgrade requirements/test.in
+	pip-compile --upgrade requirements/dev.in
 
 ##########
 # Docker #


### PR DESCRIPTION
Since I made the requirements files tiered, with `test.txt` solved using the pins from `base.txt`, and `dev.txt` solved using the pins from `base.txt` and `test.txt`, it follows that the there needs to be an order to the `pip-compile`s: `base.txt -> test.txt -> dev.txt`. If they are done in a different order that means `dev.txt` might end up being solved relative to an updated pin list and an old pin list, which will likely be incompatible.

Since the `Makefile` generates the compiles in the order `base -> dev -> test`, this is exactly what happened. This fix corrects the order.

#### Testing:
Try `make pip-compile` on `main` branch, will likely fail unless the compiles are very recent.
Try `make pip-compile` on this branch. Should succeed.