### PR TITLE
enhancement: preserve image format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 0.4.5-dev0
+## 0.4.5-dev1
 
+* Preserve image format in PIL.Image.Image when loading
 * Added ONNX version of Detectron2
 
 ## 0.4.4

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.4.5-dev0"  # pragma: no cover
+__version__ = "0.4.5-dev1"  # pragma: no cover

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -103,7 +103,10 @@ class DocumentLayout:
         """Creates a DocumentLayout from an image file."""
         logger.info(f"Reading image file: {filename} ...")
         try:
-            image = Image.open(filename).convert("RGB")
+            image = Image.open(filename)
+            format = image.format
+            image = image.convert("RGB")
+            image.format = format
         except Exception as e:
             if os.path.isdir(filename) or os.path.isfile(filename):
                 raise e


### PR DESCRIPTION
`PIL` records the filetype of the image when it's loaded, but the way we were handling the image destroyed the format metadata. This change keeps the image format metadata so that it can be recovered downstream.

#### Testing:
The following code should produce output `None` on the `main` branch and output `JPEG` on this branch.
```python
from unstructured_inference.inference.layout import DocumentLayout
doc = DocumentLayout.from_image_file("sample-docs/loremipsum.jpg")
image = doc.pages[0].image
print(image.format)

```