### PR TITLE
build(deps): pin transformers

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -3,4 +3,5 @@ python-multipart
 huggingface-hub
 opencv-python!=4.7.0.68
 onnxruntime
-transformers
+# NOTE(alan): Pinned because this is when the most recent module we import appeared
+transformers>=4.25.1


### PR DESCRIPTION
Pinning transformers at >=4.25.1. Testing on Windows just now, `pip install unstructured-inference` ended up with `transformers==4.24.x`, which caused an `ImportError` when running a smoke test due to not having a class we import. That class didn't appear until 4.25.1.

#### Testing:
If you're up for it, on a windows machine with Python:
* Install git
* Install Visual C++ Build Tools 14.x
* Clone this repo and switch to this branch
* `pip install -e .` from the base folder of this repo
* If `pycocotools` fails to build, try `pip3 install "git+https://github.com/philferriere/cocoapi.git#egg=pycocotools&subdirectory=PythonAPI"` and then try to install unstructured-inference again
* Download poppler from [here](https://github.com/oschwartz10612/poppler-windows/releases)
* Unzip poppler and add the bin folder to your path
* Install tesseract from [here](https://github.com/UB-Mannheim/tesseract/wiki)
* Add the tesseract folder to your path

Then run the usual test from the base folder of this repo with:
```python
from unstructured_inference.inference.layout import DocumentLayout
doc = DocumentLayout.from_file("sample-docs/layout-parser-paper.pdf")
print([el.text for page in doc.pages for el in page.elements])
```
No errors means success.