### PR TITLE
fix: Exception handling for ONNX runtime on blank pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.5.1 
+## 0.5.1-dev0
 
 * Hotfix to handle inference of blank pages using ONNX detectron2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.1 
+
+* Hotfix to handle inference of blank pages using ONNX detectron2
+
 ## 0.5.0
 
 * Preserve image format in PIL.Image.Image when loading

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.0"  # pragma: no cover
+__version__ = "0.5.1"  # pragma: no cover

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.1"  # pragma: no cover
+__version__ = "0.5.1-dev0"  # pragma: no cover

--- a/unstructured_inference/models/detectron2onnx.py
+++ b/unstructured_inference/models/detectron2onnx.py
@@ -49,7 +49,11 @@ class UnstructuredDetectronONNXModel(UnstructuredObjectDetectionModel):
         super().predict(image)
 
         prepared_input = self.preprocess(image)
-        bboxes, labels, confidence_scores, _ = self.model.run(None, prepared_input)
+        try:
+            bboxes, labels, confidence_scores, _ = self.model.run(None, prepared_input)
+        except onnxruntime.capi.onnxruntime_pybind11_state.RuntimeException:
+            logger.error("Something happened while inferencing page")
+            return []
         input_w, input_h = image.size
         regions = self.postprocess(bboxes, labels, confidence_scores, input_w, input_h)
 


### PR DESCRIPTION
This PR adds a try-catch during the inference with ONNX detectron2. 
A definitive solution would be to modify the ONNX model, however, doesn't seem like an easy change, and handling this error will allow the users to keep using the model.