### PR TITLE
fix: temporarily disable multicolumn logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-## 0.5.1-dev2
+## 0.5.1
 
 * Add annotation for pages
 * Store page numbers when processing PDFs
 * Hotfix to handle inference of blank pages using ONNX detectron2
+* Revert ordering change to investigate examples of misordering
 
 ## 0.5.0
 

--- a/test_unstructured_inference/inference/test_layout.py
+++ b/test_unstructured_inference/inference/test_layout.py
@@ -506,3 +506,25 @@ def test_annotate():
         assert ((annotated_array[:, :, 0] == 1).mean()) > 0.992
         assert ((annotated_array[:, :, 1] == 1).mean()) > 0.992
         assert ((annotated_array[:, :, 2] == 1).mean()) > 0.992
+
+
+@pytest.fixture
+def ordering_layout():
+    elements = [
+        layout.LayoutElement(x1=447.0, y1=315.0, x2=1275.7, y2=413.0, text="0"),
+        layout.LayoutElement(x1=380.6, y1=473.4, x2=1334.8, y2=533.9, text="1"),
+        layout.LayoutElement(x1=578.6, y1=556.8, x2=1109.0, y2=874.4, text="2"),
+        layout.LayoutElement(x1=444.5, y1=942.3, x2=1261.1, y2=1584.1, text="3"),
+        layout.LayoutElement(x1=444.8, y1=1609.4, x2=1257.2, y2=1665.2, text="4"),
+        layout.LayoutElement(x1=414.0, y1=1718.8, x2=635.0, y2=1755.2, text="5"),
+        layout.LayoutElement(x1=372.6, y1=1786.9, x2=1333.6, y2=1848.7, text="6"),
+    ]
+    return elements
+
+
+def test_layout_order(ordering_layout):
+    with patch.object(layout, "get_model", lambda: lambda x: ordering_layout):
+        doc = layout.DocumentLayout.from_file("sample-docs/layout-parser-paper.pdf")
+        page = doc.pages[0]
+    for n, element in enumerate(page.elements):
+        assert element.text == str(n)

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.1-dev2"  # pragma: no cover
+__version__ = "0.5.1"  # pragma: no cover

--- a/unstructured_inference/inference/ordering.py
+++ b/unstructured_inference/inference/ordering.py
@@ -52,6 +52,8 @@ def order_layout(
     full_page_min_width = full_page_threshold_factor * width
 
     layout.sort(key=lambda element: element.y1)
+    # NOTE(alan): Temporarily revert to orginal logic pending fixing the new logic
+    return layout
 
     sorted_layout = []
     columns: List[Column] = []

--- a/unstructured_inference/inference/ordering.py
+++ b/unstructured_inference/inference/ordering.py
@@ -1,26 +1,6 @@
-from typing import List, Union
+from typing import List
 
 from unstructured_inference.inference.elements import TextRegion
-
-
-class Column:
-    """Class to capture a column of text in the layout. Will update the midpoint of the
-    column as layout elements are added to help with new element comparisons."""
-
-    def __init__(self, layout_elements: List[TextRegion] = []):
-        self.layout_elements = layout_elements
-
-        num_elements = len(layout_elements)
-        if num_elements > 0:
-            self.x_midpoint = sum([el.x_midpoint for el in layout_elements]) / num_elements
-        else:
-            self.x_midpoint = 0
-
-    def add_element(self, layout_element: TextRegion):
-        """Adds an elements to the column and updates the midpoint."""
-        self.layout_elements.append(layout_element)
-        num_elements = len(self.layout_elements)
-        self.x_midpoint = sum([el.x_midpoint for el in self.layout_elements]) / num_elements
 
 
 def order_layout(
@@ -51,25 +31,3 @@ def order_layout(
     # NOTE(alan): Temporarily revert to orginal logic pending fixing the new logic
     # See code prior to this commit for new logic.
     return layout
-
-
-def sorted_layout_from_columns(columns: List[Column]) -> List[TextRegion]:
-    """Creates a sorted list of elements from a list of columns. Columns will be sorted
-    left to right and elements within columns are sorted top to bottom."""
-    sorted_layout = []
-    if len(columns) > 0:
-        columns.sort(key=lambda column: column.x_midpoint)
-        for column in columns:
-            column.layout_elements.sort(key=lambda element: element.y1)
-            for layout_element in column.layout_elements:
-                sorted_layout.append(layout_element)
-    return sorted_layout
-
-
-def calculate_width(layout) -> Union[float, int]:
-    """Calculates total width of the elements in the layout. Used for computing the full
-    page threshold and column tolerance."""
-    min_x1 = min([element.x1 for element in layout])
-    max_x2 = max([element.x2 for element in layout])
-
-    return max_x2 - min_x1

--- a/unstructured_inference/inference/ordering.py
+++ b/unstructured_inference/inference/ordering.py
@@ -47,36 +47,10 @@ def order_layout(
     if len(layout) == 0:
         return []
 
-    width = calculate_width(layout)
-    column_tolerance = column_tol_factor * width
-    full_page_min_width = full_page_threshold_factor * width
-
     layout.sort(key=lambda element: element.y1)
     # NOTE(alan): Temporarily revert to orginal logic pending fixing the new logic
+    # See code prior to this commit for new logic.
     return layout
-
-    sorted_layout = []
-    columns: List[Column] = []
-    for layout_element in layout:
-        if layout_element.width > full_page_min_width:
-            sorted_layout.extend(sorted_layout_from_columns(columns))
-            columns = []
-            sorted_layout.append(layout_element)
-
-        else:
-            added_to_column = False
-            for column in columns:
-                difference = abs(layout_element.x_midpoint - column.x_midpoint)
-                if difference < column_tolerance:
-                    column.add_element(layout_element)
-                    added_to_column = True
-                    break
-
-            if not added_to_column:
-                columns.append(Column(layout_elements=[layout_element]))
-
-    sorted_layout.extend(sorted_layout_from_columns(columns))
-    return sorted_layout
 
 
 def sorted_layout_from_columns(columns: List[Column]) -> List[TextRegion]:


### PR DESCRIPTION
Temporarily short circuiting the new multi-column ordering logic after seeing examples of it misordering elements where it wasn't before.

#### Testing:
I added a test to verify that a problem layout is ordered correctly, so with line 56 in `ordering.py` commented out, the test `test_layout_order` in `test_layout` should fail, and otherwise it should succeed.