### PR TITLE
enhancement: combine layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.2-dev0
+
+* Combine inferred elements with extracted elements
+
 ## 0.5.1
 
 * Add annotation for pages

--- a/setup.py
+++ b/setup.py
@@ -18,12 +18,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from setuptools import setup, find_packages
-from typing import List
+from typing import List, Optional, Union
 
 from unstructured_inference.__version__ import __version__
 
 
-def load_requirements(file_list=None):
+def load_requirements(file_list: Optional[Union[str, List[str]]] = None):
+    """Loads the requirements from a .in file or list of .in files."""
     if file_list is None:
         file_list = ["requirements/base.in"]
     if isinstance(file_list, str):
@@ -32,7 +33,9 @@ def load_requirements(file_list=None):
     for file in file_list:
         with open(file, encoding="utf-8") as f:
             requirements.extend(f.readlines())
-    requirements = [req for req in requirements if not req.startswith("#")]
+    requirements = [
+        req for req in requirements if not req.startswith("#") and not req.startswith("-")
+    ]
     return requirements
 
 

--- a/test_unstructured_inference/inference/test_layout.py
+++ b/test_unstructured_inference/inference/test_layout.py
@@ -506,3 +506,31 @@ def test_annotate():
         assert ((annotated_array[:, :, 0] == 1).mean()) > 0.992
         assert ((annotated_array[:, :, 1] == 1).mean()) > 0.992
         assert ((annotated_array[:, :, 2] == 1).mean()) > 0.992
+
+
+def test_textregion_returns_empty_ocr_never(mock_image):
+    tr = elements.TextRegion(0, 0, 24, 24)
+    assert tr.extract_text(objects=None, image=mock_image, ocr_strategy="never") == ""
+
+
+@pytest.mark.parametrize(("text", "expected"), [("asdf", "asdf"), (None, "")])
+def test_embedded_text_region(text, expected):
+    etr = elements.EmbeddedTextRegion(0, 0, 24, 24, text=text)
+    assert etr.extract_text(objects=None) == expected
+
+
+@pytest.mark.parametrize(
+    ("text", "ocr_strategy", "expected"),
+    [
+        (None, "never", ""),
+        (None, "always", "asdf"),
+        ("i have text", "never", "i have text"),
+        ("i have text", "always", "i have text"),
+    ],
+)
+def test_image_text_region(text, ocr_strategy, expected, mock_image):
+    itr = elements.ImageTextRegion(0, 0, 24, 24, text=text)
+    with patch.object(elements, "ocr", return_value="asdf"):
+        assert (
+            itr.extract_text(objects=None, image=mock_image, ocr_strategy=ocr_strategy) == expected
+        )

--- a/test_unstructured_inference/models/test_yolox.py
+++ b/test_unstructured_inference/models/test_yolox.py
@@ -5,7 +5,7 @@ import pytest
 from unstructured_inference.inference.layout import process_file_with_model
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_layout_yolox_local_parsing_image():
     filename = os.path.join("sample-docs", "test-image.jpg")
     # NOTE(benjamin) keep_output = True create a file for each image in
@@ -17,7 +17,7 @@ def test_layout_yolox_local_parsing_image():
     assert len(document_layout.pages[0].elements) == 13
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_layout_yolox_local_parsing_pdf():
     filename = os.path.join("sample-docs", "loremipsum.pdf")
     document_layout = process_file_with_model(filename, model_name="yolox")
@@ -28,7 +28,7 @@ def test_layout_yolox_local_parsing_pdf():
     assert len(document_layout.pages[0].elements) == 5
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_layout_yolox_local_parsing_empty_pdf():
     filename = os.path.join("sample-docs", "empty-document.pdf")
     document_layout = process_file_with_model(filename, model_name="yolox")
@@ -68,4 +68,7 @@ def test_layout_yolox_local_parsing_empty_pdf_soft():
     document_layout = process_file_with_model(filename, model_name="yolox_tiny")
     assert len(document_layout.pages) == 1
     # NOTE(benjamin) The example sent to the test contains 0 detections
-    assert len(document_layout.pages[0].elements) == 0
+    text_elements_page_1 = [
+        el for el in document_layout.pages[0].elements if not el.type == "Image"
+    ]
+    assert len(text_elements_page_1) == 0

--- a/test_unstructured_inference/test_elements.py
+++ b/test_unstructured_inference/test_elements.py
@@ -4,7 +4,6 @@ from unittest.mock import PropertyMock, patch
 import pytest
 
 from unstructured_inference.inference import elements
-from unstructured_inference.inference.layout import load_pdf
 
 
 def intersect_brute(rect1, rect2):
@@ -19,6 +18,83 @@ def rand_rect(size=10):
     x1 = randint(0, 30 - size)
     y1 = randint(0, 30 - size)
     return elements.Rectangle(x1, y1, x1 + size, y1 + size)
+
+
+# TODO(alan): Make a better test layout
+@pytest.fixture
+def sample_layout():
+    return [
+        elements.EmbeddedTextRegion(
+            x1=453.00277777777774,
+            y1=317.319341111111,
+            x2=711.5338541666665,
+            y2=358.28571222222206,
+            text="LayoutParser:",
+        ),
+        elements.EmbeddedTextRegion(
+            x1=726.4778125,
+            y1=317.319341111111,
+            x2=760.3308594444444,
+            y2=357.1698966666667,
+            text="A",
+        ),
+        elements.EmbeddedTextRegion(
+            x1=775.2748177777777,
+            y1=317.319341111111,
+            x2=917.3579885555555,
+            y2=357.1698966666667,
+            text="Unified",
+        ),
+        elements.EmbeddedTextRegion(
+            x1=932.3019468888888,
+            y1=317.319341111111,
+            x2=1071.8426522222221,
+            y2=357.1698966666667,
+            text="Toolkit",
+        ),
+        elements.EmbeddedTextRegion(
+            x1=1086.7866105555556,
+            y1=317.319341111111,
+            x2=1141.2105142777777,
+            y2=357.1698966666667,
+            text="for",
+        ),
+        elements.EmbeddedTextRegion(
+            x1=1156.154472611111,
+            y1=317.319341111111,
+            x2=1256.334784222222,
+            y2=357.1698966666667,
+            text="Deep",
+        ),
+        elements.EmbeddedTextRegion(
+            x1=437.83888888888885,
+            y1=367.13322999999986,
+            x2=610.0171992222222,
+            y2=406.9837855555556,
+            text="Learning",
+        ),
+        elements.EmbeddedTextRegion(
+            x1=624.9611575555555,
+            y1=367.13322999999986,
+            x2=741.6754646666665,
+            y2=406.9837855555556,
+            text="Based",
+        ),
+        elements.EmbeddedTextRegion(
+            x1=756.619423,
+            y1=367.13322999999986,
+            x2=958.3867708333332,
+            y2=406.9837855555556,
+            text="Document",
+        ),
+        elements.EmbeddedTextRegion(
+            x1=973.3307291666665,
+            y1=367.13322999999986,
+            x2=1092.0535042777776,
+            y2=406.9837855555556,
+            text="Image",
+        ),
+    ]
 
 
 @pytest.mark.parametrize("second_size", (10, 20))
@@ -88,13 +164,13 @@ def test_minimal_containing_rect():
         assert rect2.is_in(big_rect)
 
 
-def test_partition_groups_from_regions():
-    words, _ = load_pdf("sample-docs/layout-parser-paper.pdf")
-    groups = elements.partition_groups_from_regions(words[0])
-    assert len(groups) == 9
+def test_partition_groups_from_regions(sample_layout):
+    words = sample_layout
+    groups = elements.partition_groups_from_regions(words)
+    assert len(groups) == 1
     sorted_groups = sorted(groups, key=lambda group: group[0].y1)
     text = "".join([el.text for el in sorted_groups[-1]])
-    assert text.startswith("Deep")
+    assert text.startswith("Layout")
 
 
 def test_rectangle_area(monkeypatch):

--- a/test_unstructured_inference/test_elements.py
+++ b/test_unstructured_inference/test_elements.py
@@ -1,6 +1,8 @@
 from random import randint
 from unittest.mock import PropertyMock, patch
+
 import pytest
+
 from unstructured_inference.inference import elements
 from unstructured_inference.inference.layout import load_pdf
 
@@ -100,9 +102,11 @@ def test_rectangle_area(monkeypatch):
         width = randint(0, 20)
         height = randint(0, 20)
         with patch(
-            "unstructured_inference.inference.elements.Rectangle.height", new_callable=PropertyMock
+            "unstructured_inference.inference.elements.Rectangle.height",
+            new_callable=PropertyMock,
         ) as mockheight, patch(
-            "unstructured_inference.inference.elements.Rectangle.width", new_callable=PropertyMock
+            "unstructured_inference.inference.elements.Rectangle.width",
+            new_callable=PropertyMock,
         ) as mockwidth:
             rect = elements.Rectangle(0, 0, 0, 0)
             mockheight.return_value = height

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.1"  # pragma: no cover
+__version__ = "0.5.2-dev0"  # pragma: no cover

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -240,7 +240,9 @@ class PageLayout:
         else:
             page.elements = page.get_elements_from_layout(fixed_layout)
         if layout is not None:
-            page.elements = merge_inferred_layout_with_extracted_layout(page.elements, layout)
+            page.elements = order_layout(
+                merge_inferred_layout_with_extracted_layout(page.elements, layout)
+            )
         return page
 
 

--- a/unstructured_inference/inference/layoutelement.py
+++ b/unstructured_inference/inference/layoutelement.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import Optional, Collection
 
 from layoutparser.elements.layout import TextBlock
 from PIL import Image
@@ -15,7 +15,7 @@ class LayoutElement(TextRegion):
 
     def extract_text(
         self,
-        objects: Optional[List[TextRegion]],
+        objects: Optional[Collection[TextRegion]],
         image: Optional[Image.Image] = None,
         extract_tables: bool = False,
         ocr_strategy: str = "auto",


### PR DESCRIPTION
Add logic to combine inferred elements with extracted elements.

#### Testing:

```
from unstructured_inference.inference.layout import DocumentLayout

doc = DocumentLayout.from_file("sample-docs/layout-parser-paper.pdf")
page = doc.pages[0]
for el in page.elements:
    print(el.text)
page.annotate()

```
Do this in a notebook and flip through the various pages. Compare with the same on `main` branch. Notice that it doesn't miss any text, and the text is captured perfectly.