### PR TITLE
fix: deterministic ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.4
+
+* Tweak to element ordering to make it more deterministic
+
 ## 0.5.3
 
 * Refactor for large model

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.3"  # pragma: no cover
+__version__ = "0.5.4"  # pragma: no cover

--- a/unstructured_inference/inference/ordering.py
+++ b/unstructured_inference/inference/ordering.py
@@ -27,7 +27,7 @@ def order_layout(
     if len(layout) == 0:
         return []
 
-    layout.sort(key=lambda element: (element.y1, element.x1))
+    layout.sort(key=lambda element: (element.y1, element.x1, element.y2, element.x2))
     # NOTE(alan): Temporarily revert to orginal logic pending fixing the new logic
     # See code prior to this commit for new logic.
     return layout

--- a/unstructured_inference/inference/ordering.py
+++ b/unstructured_inference/inference/ordering.py
@@ -27,7 +27,7 @@ def order_layout(
     if len(layout) == 0:
         return []
 
-    layout.sort(key=lambda element: element.y1)
+    layout.sort(key=lambda element: (element.y1, element.x1))
     # NOTE(alan): Temporarily revert to orginal logic pending fixing the new logic
     # See code prior to this commit for new logic.
     return layout


### PR DESCRIPTION
Updated ordering method to rely on upper-left x-coordinate in case of a y-coordinate tie.