### PR TITLE
Fix/pdf2image-memeory-error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
-## 0.5.4-dev
+## 0.5.4-dev1
 
+* Add functionality to write images to computer storage temporarily instead of keeping them in memory for `pdf2image.convert_from_path` 
+* Add functionality to convert a PDF in small chunks of pages at a time for `pdf2image.convert_from_path`
 * Warning for onnx version of detectron2 for empty pages suppresed.
 
 ## 0.5.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.4-dev0
+
+* Add functionality to convert a PDF in small chunks of pages at a time in `load_pdf`
+
 ## 0.5.3
 
 * Refactor for large model

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.4-dev"  # pragma: no cover
+__version__ = "0.5.4-dev1"  # pragma: no cover

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.3"  # pragma: no cover
+__version__ = "0.5.4-dev0"  # pragma: no cover

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -382,7 +382,7 @@ def get_element_from_block(
 def load_pdf(
     filename: str,
     dpi: int = 200,
-    chunk_size: int = 10,
+    chunk_size: int = 100,
 ) -> Tuple[List[List[TextRegion]], List[Image.Image]]:
     """Loads the image and word objects from a pdf using pdfplumber and the image renderings of the
     pdf pages using pdf2image"""
@@ -414,11 +414,13 @@ def load_pdf(
 
     for start_page in range(1, total_pages + 1, chunk_size):
         end_page = min(start_page + chunk_size - 1, total_pages)
-        chunk_images = pdf2image.convert_from_path(
-            filename,
-            dpi=dpi,
-            first_page=start_page,
-            last_page=end_page,
-        )
-        images += chunk_images
+        with tempfile.TemporaryDirectory() as tmpdir:
+            chunk_images = pdf2image.convert_from_path(
+                filename,
+                dpi=dpi,
+                first_page=start_page,
+                last_page=end_page,
+                output_folder=tmpdir,
+            )
+            images += chunk_images
     return layouts, images

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -382,6 +382,7 @@ def get_element_from_block(
 def load_pdf(
     filename: str,
     dpi: int = 200,
+    chunk_size: int = 10,
 ) -> Tuple[List[List[TextRegion]], List[Image.Image]]:
     """Loads the image and word objects from a pdf using pdfplumber and the image renderings of the
     pdf pages using pdf2image"""
@@ -406,5 +407,18 @@ def load_pdf(
                 layout.append(text_region)
         layouts.append(layout)
 
-    images = pdf2image.convert_from_path(filename, dpi=dpi)
+    # Convert a PDF in small chunks of pages at a time (e.g. 1-10, 11-20... and so on)
+    info = pdf2image.pdfinfo_from_path(filename)
+    total_pages = info["Pages"]
+    images = []
+
+    for start_page in range(1, total_pages + 1, chunk_size):
+        end_page = min(start_page + chunk_size - 1, total_pages)
+        chunk_images = pdf2image.convert_from_path(
+            filename,
+            dpi=dpi,
+            first_page=start_page,
+            last_page=end_page,
+        )
+        images += chunk_images
     return layouts, images


### PR DESCRIPTION
This PR is for [issue #521](https://github.com/Unstructured-IO/unstructured/issues/521)

- Add functionality to convert a PDF in small chunks of pages at a time for `pdf2image.convert_from_path`
- Add functionality to write images to computer storage temporarily instead of keeping them in memory for `pdf2image.convert_from_path`

### Testing

- Run the following command:
```
$ cd unstructured
$ pip uninstall unstructured-inference
$ git clone -b fix/pdf2image-memeory-error https://github.com/Unstructured-IO/unstructured-inference.git
$ cd unstructured-inference
$ pip install -e .
```
- Download the test pdf file from [issue #521](https://github.com/Unstructured-IO/unstructured/issues/521)
-  Run the following code and measure the memory usage.
```
filename = "example-docs/irm02-003-059--2022-12-12.pdf"
elements = partition_pdf(filename, strategy="hi_res")
print("\n\n".join([str(el) for el in elements]))
```
### Memory usage comparison result
I ran `partition_pdf` on the test document on a MacOS and an Ubuntu machine and compared the memory usage. (Both machines have 16 GB of memory)

**[Ubuntu]**
- Before updating (`main` branch)
845.4 MB → 12.9 GB or more (Running `partition_pdf` resulted in a killed process at 12.9 GB due to running out of memory)
- After updating (`fix/pdf2image-memeory-error` branch)
847.8 MB → 847.8 MB (No memory was used)

**[MacOS]**
- Before updating (`main` branch)
582.9 MB → 13.52 GB (Running `partition_pdf` did not result in a killed process due to dynamic swap scaling)
- After updating (`fix/pdf2image-memeory-error` branch)
582.9 MB → 582.9 MB (No memory was used)