### PR TITLE
rename large model to chipper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 * Table processing check for the area of the package to fix division by zero bug
 * Rename large model to chipper
-
-## 0.5.4
-
 * Added CUDA and TensorRT execution providers for yolox and detectron2onnx model. 
 * Warning for onnx version of detectron2 for empty pages suppresed.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-## 0.5.5-dev2
+## 0.5.5
 
 * Table processing check for the area of the package to fix division by zero bug
+* Rename large model to chipper
 
-## 0.5.5-dev1
+## 0.5.4
 
 * Added CUDA and TensorRT execution providers for yolox and detectron2onnx model. 
 * Warning for onnx version of detectron2 for empty pages suppresed.

--- a/test_unstructured_inference/models/test_chippermodel.py
+++ b/test_unstructured_inference/models/test_chippermodel.py
@@ -3,24 +3,24 @@ from unittest import mock
 import pytest
 from PIL import Image
 
-from unstructured_inference.models import largemodel
+from unstructured_inference.models import chipper
 
 
 def test_initialize():
     with mock.patch.object(
-        largemodel.AutoTokenizer,
+        chipper.AutoTokenizer,
         "from_pretrained",
     ) as mock_tokenizer, mock.patch.object(
-        largemodel,
+        chipper,
         "DonutProcessor",
     ) as mock_donut_processor, mock.patch.object(
-        largemodel,
+        chipper,
         "DonutImageProcessor",
     ) as mock_donut_image_processor, mock.patch.object(
-        largemodel.VisionEncoderDecoderModel,
+        chipper.VisionEncoderDecoderModel,
         "from_pretrained",
     ) as mock_vision_encoder_decoder_model:
-        model = largemodel.UnstructuredLargeModel()
+        model = chipper.UnstructuredChipperModel()
         model.initialize("", "", "")
         mock_tokenizer.assert_called_once()
         mock_donut_processor.assert_called_once()
@@ -44,8 +44,8 @@ def mock_initialize(self, *arg, **kwargs):
 
 
 def test_predict_tokens():
-    with mock.patch.object(largemodel.UnstructuredLargeModel, "initialize", mock_initialize):
-        model = largemodel.UnstructuredLargeModel()
+    with mock.patch.object(chipper.UnstructuredChipperModel, "initialize", mock_initialize):
+        model = chipper.UnstructuredChipperModel()
         model.initialize()
         with open("sample-docs/loremipsum.png", "rb") as fp:
             im = Image.open(fp)
@@ -64,9 +64,9 @@ def test_predict_tokens():
     ],
 )
 def test_postprocess(decoded_str, expected_classes):
-    with mock.patch.object(largemodel.UnstructuredLargeModel, "initialize", mock_initialize):
+    with mock.patch.object(chipper.UnstructuredChipperModel, "initialize", mock_initialize):
         pass
-    model = largemodel.UnstructuredLargeModel()
+    model = chipper.UnstructuredChipperModel()
     tokenizer_model = "xlm-roberta-large"
     pre_trained_model = "nielsr/donut-base"
     model.initialize(tokenizer_model, pre_trained_model, None)
@@ -81,13 +81,13 @@ def test_postprocess(decoded_str, expected_classes):
 
 def test_predict():
     with mock.patch.object(
-        largemodel.UnstructuredLargeModel,
+        chipper.UnstructuredChipperModel,
         "predict_tokens",
     ) as mock_predict_tokens, mock.patch.object(
-        largemodel.UnstructuredLargeModel,
+        chipper.UnstructuredChipperModel,
         "postprocess",
     ) as mock_postprocess:
-        model = largemodel.UnstructuredLargeModel()
+        model = chipper.UnstructuredChipperModel()
         model.predict("hello")
         mock_predict_tokens.assert_called_once()
         mock_postprocess.assert_called_once()

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.5-dev2"  # pragma: no cover
+__version__ = "0.5.5"  # pragma: no cover

--- a/unstructured_inference/models/base.py
+++ b/unstructured_inference/models/base.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+from unstructured_inference.models.chipper import MODEL_TYPES as CHIPPER_MODEL_TYPES
+from unstructured_inference.models.chipper import UnstructuredChipperModel
 from unstructured_inference.models.detectron2 import (
     MODEL_TYPES as DETECTRON2_MODEL_TYPES,
 )
@@ -12,8 +14,6 @@ from unstructured_inference.models.detectron2onnx import (
 from unstructured_inference.models.detectron2onnx import (
     UnstructuredDetectronONNXModel,
 )
-from unstructured_inference.models.chipper import MODEL_TYPES as CHIPPER_MODEL_TYPES
-from unstructured_inference.models.chipper import UnstructuredChipperModel
 from unstructured_inference.models.unstructuredmodel import UnstructuredModel
 from unstructured_inference.models.yolox import (
     MODEL_TYPES as YOLOX_MODEL_TYPES,

--- a/unstructured_inference/models/base.py
+++ b/unstructured_inference/models/base.py
@@ -12,8 +12,8 @@ from unstructured_inference.models.detectron2onnx import (
 from unstructured_inference.models.detectron2onnx import (
     UnstructuredDetectronONNXModel,
 )
-from unstructured_inference.models.largemodel import MODEL_TYPES as LARGE_MODEL_TYPES
-from unstructured_inference.models.largemodel import UnstructuredLargeModel
+from unstructured_inference.models.chipper import MODEL_TYPES as CHIPPER_MODEL_TYPES
+from unstructured_inference.models.chipper import UnstructuredChipperModel
 from unstructured_inference.models.unstructuredmodel import UnstructuredModel
 from unstructured_inference.models.yolox import (
     MODEL_TYPES as YOLOX_MODEL_TYPES,
@@ -41,9 +41,9 @@ def get_model(model_name: Optional[str] = None) -> UnstructuredModel:
     elif model_name in YOLOX_MODEL_TYPES:
         model = UnstructuredYoloXModel()
         model.initialize(**YOLOX_MODEL_TYPES[model_name])
-    elif model_name in LARGE_MODEL_TYPES:
-        model = UnstructuredLargeModel()
-        model.initialize(**LARGE_MODEL_TYPES[model_name])
+    elif model_name in CHIPPER_MODEL_TYPES:
+        model = UnstructuredChipperModel()
+        model.initialize(**CHIPPER_MODEL_TYPES[model_name])
     else:
         raise UnknownModelException(f"Unknown model type: {model_name}")
     return model

--- a/unstructured_inference/models/chipper.py
+++ b/unstructured_inference/models/chipper.py
@@ -15,7 +15,7 @@ from unstructured_inference.inference.layoutelement import LocationlessLayoutEle
 from unstructured_inference.models.unstructuredmodel import UnstructuredElementExtractionModel
 
 MODEL_TYPES = {
-    "large_model": {
+    "chipper": {
         "tokenizer_name": "xlm-roberta-large",
         "pre_trained_model_name": "unstructuredio/ved-fine-tuning",
     },
@@ -57,7 +57,7 @@ SPECIAL_TAGS = ["<sep/>"] + [
 ]
 
 
-class UnstructuredLargeModel(UnstructuredElementExtractionModel):
+class UnstructuredChipperModel(UnstructuredElementExtractionModel):
     required_w: int = 1248
     required_h: int = 1664
 


### PR DESCRIPTION
To make the new large model more customer centric, renaming it to chipper and setting a new release as this is a breaking change. 