### PR TITLE
fix installation with python 3.8.17

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,15 +10,13 @@ certifi==2023.5.7
     # via requests
 cffi==1.15.1
     # via cryptography
-charset-normalizer==3.1.0
+charset-normalizer==3.2.0
     # via
     #   pdfminer-six
     #   requests
-cmake==3.26.4
-    # via triton
 coloredlogs==15.0.1
     # via onnxruntime
-contourpy==1.0.7
+contourpy==1.1.0
     # via matplotlib
 cryptography==41.0.1
     # via pdfminer-six
@@ -26,27 +24,28 @@ cycler==0.11.0
     # via matplotlib
 effdet==0.4.1
     # via layoutparser
-filelock==3.12.0
+filelock==3.12.2
     # via
     #   huggingface-hub
     #   torch
     #   transformers
-    #   triton
 flatbuffers==23.5.26
     # via onnxruntime
-fonttools==4.39.4
+fonttools==4.40.0
     # via matplotlib
-fsspec==2023.5.0
+fsspec==2023.6.0
     # via huggingface-hub
-huggingface-hub==0.15.1
+huggingface-hub==0.16.4
     # via
-    #   -r base.in
+    #   -r requirements/base.in
     #   timm
     #   transformers
 humanfriendly==10.0
     # via coloredlogs
 idna==3.4
     # via requests
+importlib-resources==6.0.0
+    # via matplotlib
 iopath==0.1.10
     # via layoutparser
 jinja2==3.1.2
@@ -54,18 +53,16 @@ jinja2==3.1.2
 kiwisolver==1.4.4
     # via matplotlib
 layoutparser[layoutmodels,tesseract]==0.3.4
-    # via -r base.in
-lit==16.0.6
-    # via triton
+    # via -r requirements/base.in
 markupsafe==2.1.3
     # via jinja2
-matplotlib==3.7.1
+matplotlib==3.7.2
     # via pycocotools
 mpmath==1.3.0
     # via sympy
 networkx==3.1
     # via torch
-numpy==1.24.3
+numpy==1.24.4
     # via
     #   contourpy
     #   layoutparser
@@ -80,10 +77,10 @@ numpy==1.24.3
 omegaconf==2.3.0
     # via effdet
 onnxruntime==1.15.1
-    # via -r base.in
-opencv-python==4.7.0.72
+    # via -r requirements/base.in
+opencv-python==4.8.0.74
     # via
-    #   -r base.in
+    #   -r requirements/base.in
     #   layoutparser
 packaging==23.1
     # via
@@ -92,7 +89,7 @@ packaging==23.1
     #   onnxruntime
     #   pytesseract
     #   transformers
-pandas==2.0.2
+pandas==2.0.3
     # via layoutparser
 pdf2image==1.16.3
     # via layoutparser
@@ -100,7 +97,7 @@ pdfminer-six==20221105
     # via pdfplumber
 pdfplumber==0.9.0
     # via layoutparser
-pillow==9.5.0
+pillow==10.0.0
     # via
     #   layoutparser
     #   matplotlib
@@ -110,7 +107,7 @@ pillow==9.5.0
     #   torchvision
 portalocker==2.7.0
     # via iopath
-protobuf==4.23.2
+protobuf==4.23.4
     # via onnxruntime
 pycocotools==2.0.6
     # via effdet
@@ -125,7 +122,7 @@ python-dateutil==2.8.2
     #   matplotlib
     #   pandas
 python-multipart==0.0.6
-    # via -r base.in
+    # via -r requirements/base.in
 pytz==2023.3
     # via pandas
 pyyaml==6.0
@@ -143,7 +140,9 @@ requests==2.31.0
     #   torchvision
     #   transformers
 safetensors==0.3.1
-    # via timm
+    # via
+    #   timm
+    #   transformers
 scipy==1.10.1
     # via layoutparser
 six==1.16.0
@@ -162,7 +161,6 @@ torch==2.0.1
     #   layoutparser
     #   timm
     #   torchvision
-    #   triton
 torchvision==0.15.2
     # via
     #   effdet
@@ -173,26 +171,18 @@ tqdm==4.65.0
     #   huggingface-hub
     #   iopath
     #   transformers
-transformers==4.29.2
-    # via -r base.in
-triton==2.0.0
-    # via torch
-typing-extensions==4.6.3
+transformers==4.30.2
+    # via -r requirements/base.in
+typing-extensions==4.7.1
     # via
     #   huggingface-hub
     #   iopath
     #   torch
 tzdata==2023.3
     # via pandas
-urllib3==2.0.2
+urllib3==2.0.3
     # via requests
 wand==0.6.11
     # via pdfplumber
-wheel==0.40.0
-    # via
-    #   nvidia-cublas-cu11
-    #   nvidia-cuda-cupti-cu11
-    #   nvidia-cuda-runtime-cu11
-    #   nvidia-curand-cu11
-    #   nvidia-cusparse-cu11
-    #   nvidia-nvtx-cu11
+zipp==3.16.0
+    # via importlib-resources

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile requirements/dev.in
 #
-anyio==3.7.0
+anyio==3.7.1
     # via
     #   -c requirements/test.txt
     #   jupyter-server
@@ -22,7 +22,9 @@ argon2-cffi-bindings==21.2.0
 asttokens==2.2.1
     # via stack-data
 attrs==23.1.0
-    # via jsonschema
+    # via
+    #   jsonschema
+    #   referencing
 backcall==0.2.0
     # via ipython
 beautifulsoup4==4.12.2
@@ -35,7 +37,7 @@ cffi==1.15.1
     # via
     #   -c requirements/base.txt
     #   argon2-cffi-bindings
-click==8.1.3
+click==8.1.4
     # via
     #   -c requirements/test.txt
     #   pip-tools
@@ -49,7 +51,7 @@ defusedxml==0.7.1
     # via nbconvert
 entrypoints==0.4
     # via jupyter-client
-exceptiongroup==1.1.1
+exceptiongroup==1.1.2
     # via
     #   -c requirements/test.txt
     #   anyio
@@ -62,13 +64,14 @@ idna==3.4
     #   -c requirements/base.txt
     #   -c requirements/test.txt
     #   anyio
-importlib-metadata==6.6.0
+importlib-metadata==6.8.0
     # via nbconvert
-importlib-resources==5.12.0
+importlib-resources==6.0.0
     # via
     #   -c requirements/base.txt
     #   jsonschema
-ipykernel==6.23.1
+    #   jsonschema-specifications
+ipykernel==6.24.0
     # via
     #   ipywidgets
     #   jupyter
@@ -87,7 +90,7 @@ ipython-genutils==0.2.0
     #   nbclassic
     #   notebook
     #   qtconsole
-ipywidgets==8.0.6
+ipywidgets==8.0.7
     # via jupyter
 jedi==0.18.2
     # via ipython
@@ -98,8 +101,10 @@ jinja2==3.1.2
     #   nbclassic
     #   nbconvert
     #   notebook
-jsonschema==4.17.3
+jsonschema==4.18.0
     # via nbformat
+jsonschema-specifications==2023.6.1
+    # via jsonschema
 jupyter==1.0.0
     # via -r requirements/dev.in
 jupyter-client==7.3.4
@@ -114,7 +119,7 @@ jupyter-client==7.3.4
     #   qtconsole
 jupyter-console==6.6.3
     # via jupyter
-jupyter-core==5.3.0
+jupyter-core==5.3.1
     # via
     #   ipykernel
     #   jupyter-client
@@ -133,7 +138,7 @@ jupyter-server==1.23.6
     #   notebook-shim
 jupyterlab-pygments==0.2.2
     # via nbconvert
-jupyterlab-widgets==3.0.7
+jupyterlab-widgets==3.0.8
     # via ipywidgets
 markupsafe==2.1.3
     # via
@@ -144,19 +149,19 @@ matplotlib-inline==0.1.6
     # via
     #   ipykernel
     #   ipython
-mistune==2.0.5
+mistune==3.0.1
     # via nbconvert
 nbclassic==1.0.0
     # via notebook
 nbclient==0.8.0
     # via nbconvert
-nbconvert==7.4.0
+nbconvert==7.6.0
     # via
     #   jupyter
     #   jupyter-server
     #   nbclassic
     #   notebook
-nbformat==5.9.0
+nbformat==5.9.1
     # via
     #   jupyter-server
     #   nbclassic
@@ -191,20 +196,20 @@ pexpect==4.8.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-pip-tools==6.13.0
+pip-tools==6.14.0
     # via -r requirements/dev.in
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-platformdirs==3.5.1
+platformdirs==3.8.1
     # via
     #   -c requirements/test.txt
     #   jupyter-core
-prometheus-client==0.17.0
+prometheus-client==0.17.1
     # via
     #   jupyter-server
     #   nbclassic
     #   notebook
-prompt-toolkit==3.0.38
+prompt-toolkit==3.0.39
     # via
     #   ipython
     #   jupyter-console
@@ -228,8 +233,6 @@ pygments==2.15.1
     #   qtconsole
 pyproject-hooks==1.0.0
     # via build
-pyrsistent==0.19.3
-    # via jsonschema
 python-dateutil==2.8.2
     # via
     #   -c requirements/base.txt
@@ -247,6 +250,14 @@ qtconsole==5.4.3
     # via jupyter
 qtpy==2.3.1
     # via qtconsole
+referencing==0.29.1
+    # via
+    #   jsonschema
+    #   jsonschema-specifications
+rpds-py==0.8.10
+    # via
+    #   jsonschema
+    #   referencing
 send2trash==1.8.2
     # via
     #   jupyter-server
@@ -277,6 +288,7 @@ tomli==2.0.1
     # via
     #   -c requirements/test.txt
     #   build
+    #   pip-tools
     #   pyproject-hooks
 tornado==6.1
     # via
@@ -304,7 +316,7 @@ traitlets==5.9.0
     #   nbformat
     #   notebook
     #   qtconsole
-typing-extensions==4.6.3
+typing-extensions==4.7.1
     # via
     #   -c requirements/base.txt
     #   -c requirements/test.txt
@@ -315,13 +327,13 @@ webencodings==0.5.1
     # via
     #   bleach
     #   tinycss2
-websocket-client==1.5.2
+websocket-client==1.6.1
     # via jupyter-server
 wheel==0.40.0
     # via pip-tools
-widgetsnbextension==4.0.7
+widgetsnbextension==4.0.8
     # via ipywidgets
-zipp==3.15.0
+zipp==3.16.0
     # via
     #   -c requirements/base.txt
     #   importlib-metadata

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,55 +4,59 @@
 #
 #    pip-compile requirements/test.in
 #
-anyio==3.7.0
+anyio==3.7.1
     # via httpcore
-black==23.3.0
-    # via -r test.in
+black==23.7.0
+    # via -r requirements/test.in
 certifi==2023.5.7
     # via
-    #   -c base.txt
+    #   -c requirements/base.txt
     #   httpcore
     #   httpx
     #   requests
-charset-normalizer==3.1.0
+charset-normalizer==3.2.0
     # via
-    #   -c base.txt
+    #   -c requirements/base.txt
     #   requests
-click==8.1.3
+click==8.1.4
     # via
-    #   -r test.in
+    #   -r requirements/test.in
     #   black
 coverage[toml]==7.2.7
     # via
-    #   -r test.in
+    #   -r requirements/test.in
     #   pytest-cov
-filelock==3.12.0
+exceptiongroup==1.1.2
     # via
-    #   -c base.txt
+    #   anyio
+    #   pytest
+filelock==3.12.2
+    # via
+    #   -c requirements/base.txt
     #   huggingface-hub
 flake8==6.0.0
     # via
-    #   -r test.in
+    #   -r requirements/test.in
     #   flake8-docstrings
 flake8-docstrings==1.7.0
-    # via -r test.in
-fsspec==2023.5.0
+    # via -r requirements/test.in
+fsspec==2023.6.0
     # via
-    #   -c base.txt
+    #   -c requirements/base.txt
     #   huggingface-hub
 h11==0.14.0
     # via httpcore
-httpcore==0.17.2
+httpcore==0.17.3
     # via httpx
 httpx==0.24.1
-    # via -r test.in
-huggingface-hub==0.15.1
+    # via -r requirements/test.in
+huggingface-hub==0.16.4
     # via
-    #   -c base.txt
-    #   -r test.in
+    #   -c requirements/base.txt
+    #   -r requirements/test.in
 idna==3.4
     # via
-    #   -c base.txt
+    #   -c requirements/base.txt
     #   anyio
     #   httpx
     #   requests
@@ -61,14 +65,14 @@ iniconfig==2.0.0
 mccabe==0.7.0
     # via flake8
 mypy==1.4.1
-    # via -r test.in
+    # via -r requirements/test.in
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
 packaging==23.1
     # via
-    #   -c base.txt
+    #   -c requirements/base.txt
     #   black
     #   huggingface-hub
     #   pytest
@@ -76,15 +80,15 @@ pathspec==0.11.1
     # via black
 pdf2image==1.16.3
     # via
-    #   -c base.txt
-    #   -r test.in
-pillow==9.5.0
+    #   -c requirements/base.txt
+    #   -r requirements/test.in
+pillow==10.0.0
     # via
-    #   -c base.txt
+    #   -c requirements/base.txt
     #   pdf2image
-platformdirs==3.5.1
+platformdirs==3.8.1
     # via black
-pluggy==1.0.0
+pluggy==1.2.0
     # via pytest
 pycodestyle==2.10.0
     # via flake8
@@ -92,20 +96,20 @@ pydocstyle==6.3.0
     # via flake8-docstrings
 pyflakes==3.0.1
     # via flake8
-pytest==7.3.1
+pytest==7.4.0
     # via pytest-cov
 pytest-cov==4.1.0
-    # via -r test.in
+    # via -r requirements/test.in
 pyyaml==6.0
     # via
-    #   -c base.txt
+    #   -c requirements/base.txt
     #   huggingface-hub
 requests==2.31.0
     # via
-    #   -c base.txt
+    #   -c requirements/base.txt
     #   huggingface-hub
-ruff==0.0.276
-    # via -r test.in
+ruff==0.0.277
+    # via -r requirements/test.in
 sniffio==1.3.0
     # via
     #   anyio
@@ -113,16 +117,23 @@ sniffio==1.3.0
     #   httpx
 snowballstemmer==2.2.0
     # via pydocstyle
+tomli==2.0.1
+    # via
+    #   black
+    #   coverage
+    #   mypy
+    #   pytest
 tqdm==4.65.0
     # via
-    #   -c base.txt
+    #   -c requirements/base.txt
     #   huggingface-hub
-typing-extensions==4.6.3
+typing-extensions==4.7.1
     # via
-    #   -c base.txt
+    #   -c requirements/base.txt
+    #   black
     #   huggingface-hub
     #   mypy
-urllib3==2.0.2
+urllib3==2.0.3
     # via
-    #   -c base.txt
+    #   -c requirements/base.txt
     #   requests


### PR DESCRIPTION
This PR just makes pip-compile to requirements in -dev version.
With the current code is not possible to install unstructured along side unstructured-inference, `make install` on the last one return: 
`ERROR: Ignored the following versions that require a different python version: 1.25.0 Requires-Python >=3.9; 1.25.0rc1 Requires-Python >=3.9; 1.25.1 Requires-Python >=3.9
ERROR: Could not find a version that satisfies the requirement triton==2.0.0 (from versions: none)
ERROR: No matching distribution found for triton==2.0.0`

In order to check:
* git clone unstructured && cd unstructured
* make install
* git clone unstructured-inference && cd unstructured-inference
* make install  

Should install without issues.