### PR TITLE
enhancement: expose dpi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 0.5.6-dev0
+## 0.5.6-dev1
 
 * Warns users that Chipper is a beta model.
+* Exposed control over dpi when converting PDF to an image.
 
 ## 0.5.5
 

--- a/test_unstructured_inference/inference/test_layout.py
+++ b/test_unstructured_inference/inference/test_layout.py
@@ -739,4 +739,12 @@ def test_process_file_with_model_routing(monkeypatch, model_type, is_detection_m
             ocr_languages="eng",
             fixed_layouts=None,
             extract_tables=False,
+            pdf_image_dpi=200,
         )
+
+
+@pytest.mark.parametrize(("pdf_image_dpi", "expected"), [(200, 2200), (100, 1100)])
+def test_exposed_pdf_image_dpi(pdf_image_dpi, expected, monkeypatch):
+    with patch.object(layout.PageLayout, "from_image") as mock_from_image:
+        layout.DocumentLayout.from_file("sample-docs/loremipsum.pdf", pdf_image_dpi=pdf_image_dpi)
+        assert mock_from_image.call_args[0][0].height == expected

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.6-dev0"  # pragma: no cover
+__version__ = "0.5.6-dev1"  # pragma: no cover

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -77,10 +77,11 @@ class DocumentLayout:
         ocr_strategy: str = "auto",
         ocr_languages: str = "eng",
         extract_tables: bool = False,
+        pdf_image_dpi: int = 200,
     ) -> DocumentLayout:
         """Creates a DocumentLayout from a pdf file."""
         logger.info(f"Reading PDF for file: {filename} ...")
-        layouts, images = load_pdf(filename)
+        layouts, images = load_pdf(filename, pdf_image_dpi)
         if len(layouts) > len(images):
             raise RuntimeError(
                 "Some images were not loaded. Check that poppler is installed and in your $PATH.",
@@ -297,6 +298,7 @@ def process_data_with_model(
     ocr_languages: str = "eng",
     fixed_layouts: Optional[List[Optional[List[TextRegion]]]] = None,
     extract_tables: bool = False,
+    pdf_image_dpi: int = 200,
 ) -> DocumentLayout:
     """Processes pdf file in the form of a file handler (supporting a read method) into a
     DocumentLayout by using a model identified by model_name."""
@@ -310,6 +312,7 @@ def process_data_with_model(
             ocr_languages=ocr_languages,
             fixed_layouts=fixed_layouts,
             extract_tables=extract_tables,
+            pdf_image_dpi=pdf_image_dpi,
         )
 
     return layout
@@ -323,6 +326,7 @@ def process_file_with_model(
     ocr_languages: str = "eng",
     fixed_layouts: Optional[List[Optional[List[TextRegion]]]] = None,
     extract_tables: bool = False,
+    pdf_image_dpi: int = 200,
 ) -> DocumentLayout:
     """Processes pdf file with name filename into a DocumentLayout by using a model identified by
     model_name."""
@@ -353,6 +357,7 @@ def process_file_with_model(
             ocr_languages=ocr_languages,
             fixed_layouts=fixed_layouts,
             extract_tables=extract_tables,
+            pdf_image_dpi=pdf_image_dpi,
         )
     )
     return layout


### PR DESCRIPTION
Exposed pdf-to-image conversion dpi parameter to higher level functions so this parameter can be set externally.

#### Testing:
```
from unstructured_inference.inference.layout import DocumentLayout
doc = DocumentLayout.from_file("sample-docs/loremipsum.pdf", pdf_image_dpi=200)
print(doc.pages[0].image.height) # Should be 2200
doc = DocumentLayout.from_file("sample-docs/loremipsum.pdf", pdf_image_dpi=100)
print(doc.pages[0].image.height) # Should be 1100

```