### PR TITLE
build(deps): update detectron2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-## 0.5.6-dev1
+## 0.5.6-dev2
 
 * Warns users that Chipper is a beta model.
 * Exposed control over dpi when converting PDF to an image.
+* Updated detectron2 version to avoid errors related to deprecated PIL reference
 
 ## 0.5.5
 

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ install-base-pip-packages:
 
 .PHONY: install-detectron2
 install-detectron2:
-	pip install "detectron2@git+https://github.com/facebookresearch/detectron2.git@e2ce8dc#egg=detectron2"
+	pip install "detectron2@git+https://github.com/facebookresearch/detectron2.git@a2e43ea#egg=detectron2"
 
 .PHONY: install-paddleocr
 install-paddleocr:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Run `pip install unstructured-inference`.
 but is not automatically installed with this package. 
 For MacOS and Linux, build from source with:
 ```shell
-pip install 'git+https://github.com/facebookresearch/detectron2.git@e2ce8dc#egg=detectron2'
+pip install 'git+https://github.com/facebookresearch/detectron2.git@a2e43ea#egg=detectron2'
 ```
 Other install options can be found in the 
 [Detectron2 installation guide](https://detectron2.readthedocs.io/en/latest/tutorials/install.html).

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.6-dev1"  # pragma: no cover
+__version__ = "0.5.6-dev2"  # pragma: no cover


### PR DESCRIPTION
I noticed an issue that basic operations in this library were causing import errors. This turned out to be caused by the new version of `PIL` completing deprecation of certain references (specifically `PIL.Image.LINEAR`) used in the pinned version of `detectron2` that we've been using. Updating to the latest commit of `detectron2` fixes the problem.

#### Testing:
From a fresh environment, run `make install` from the `main` branch and observe that running `from unstructured_inference.inference.layout import DocumentLayout` causes an import error from within the `detectron2` code.

Subsequently, if you `pip uninstall detectron2`, switch to this branch, run `make install-detectron2`, and rerun the code, it should succeed.