### PR TITLE
enhancement: cache named models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 0.5.6-dev2
+## 0.5.6-dev3
 
+* Cache named models that have been lodaed
 * Update the `annotate` and `_get_image_array` methods of `PageLayout` to get the image from the `image_path` property if the `image` property is `None`.
 * Add functionality to store pdf images for later use.
 * Add `image_metadata` property to `PageLayout` & set `page.image` to None to reduce memory usage.

--- a/test_unstructured_inference/models/test_detectron2.py
+++ b/test_unstructured_inference/models/test_detectron2.py
@@ -17,14 +17,17 @@ class MockDetectron2LayoutModel:
 
 def test_load_default_model(monkeypatch):
     monkeypatch.setattr(detectron2, "Detectron2LayoutModel", MockDetectron2LayoutModel)
+    monkeypatch.setattr(models, "models", {})
 
     with patch.object(detectron2, "is_detectron2_available", return_value=True):
         model = models.get_model("detectron2_lp")
 
+    print(type(model))
     assert isinstance(model.model, MockDetectron2LayoutModel)
 
 
-def test_load_default_model_raises_when_not_available():
+def test_load_default_model_raises_when_not_available(monkeypatch):
+    monkeypatch.setattr(models, "models", {})
     with patch.object(detectron2, "is_detectron2_available", return_value=False):
         with pytest.raises(ImportError):
             models.get_model("detectron2_lp")

--- a/test_unstructured_inference/models/test_detectron2.py
+++ b/test_unstructured_inference/models/test_detectron2.py
@@ -22,7 +22,6 @@ def test_load_default_model(monkeypatch):
     with patch.object(detectron2, "is_detectron2_available", return_value=True):
         model = models.get_model("detectron2_lp")
 
-    print(type(model))
     assert isinstance(model.model, MockDetectron2LayoutModel)
 
 

--- a/test_unstructured_inference/models/test_detectron2onnx.py
+++ b/test_unstructured_inference/models/test_detectron2onnx.py
@@ -23,7 +23,8 @@ class MockDetectron2ONNXLayoutModel:
         return [input_thing()]
 
 
-def test_load_default_model():
+def test_load_default_model(monkeypatch):
+    monkeypatch.setattr(models, "models", {})
     with patch.object(
         detectron2.onnxruntime,
         "InferenceSession",

--- a/test_unstructured_inference/models/test_model.py
+++ b/test_unstructured_inference/models/test_model.py
@@ -1,10 +1,13 @@
 from typing import Any
-import pytest
 from unittest import mock
 
+import pytest
+
 import unstructured_inference.models.base as models
-from unstructured_inference.models.unstructuredmodel import UnstructuredObjectDetectionModel
-from unstructured_inference.models.unstructuredmodel import ModelNotInitializedError
+from unstructured_inference.models.unstructuredmodel import (
+    ModelNotInitializedError,
+    UnstructuredObjectDetectionModel,
+)
 
 
 class MockModel(UnstructuredObjectDetectionModel):

--- a/test_unstructured_inference/models/test_model.py
+++ b/test_unstructured_inference/models/test_model.py
@@ -60,7 +60,9 @@ def test_model_initializes_once():
     from unstructured_inference.inference import layout
 
     with mock.patch.object(models, "UnstructuredDetectronONNXModel", MockModel), mock.patch.object(
-        models, "models", {}
+        models,
+        "models",
+        {},
     ):
         doc = layout.DocumentLayout.from_file("sample-docs/layout-parser-paper.pdf")
 

--- a/test_unstructured_inference/models/test_model.py
+++ b/test_unstructured_inference/models/test_model.py
@@ -1,12 +1,19 @@
+from typing import Any
 import pytest
+from unittest import mock
 
 import unstructured_inference.models.base as models
+from unstructured_inference.models.unstructuredmodel import UnstructuredObjectDetectionModel
 from unstructured_inference.models.unstructuredmodel import ModelNotInitializedError
 
 
-class MockModel:
-    def initialize(self, *args, **kwargs):
-        pass
+class MockModel(UnstructuredObjectDetectionModel):
+    initialize = mock.MagicMock()
+    # def initialize(self, *args, **kwargs):
+    #     pass
+
+    def predict(self, x: Any) -> Any:
+        return []
 
 
 def test_get_model(monkeypatch):
@@ -36,3 +43,11 @@ def test_raises_invalid_model():
 def test_raises_uninitialized():
     with pytest.raises(ModelNotInitializedError):
         models.UnstructuredDetectronModel().predict(None)
+
+
+def test_model_initializes_once():
+    with mock.patch.object(models, "UnstructuredDetectronONNXModel", MockModel) as f:
+        from unstructured_inference.inference.layout import DocumentLayout
+
+        DocumentLayout.from_file("sample-docs/layout-parser-paper.pdf")
+        f.initialize.assert_called_once()

--- a/test_unstructured_inference/models/test_model.py
+++ b/test_unstructured_inference/models/test_model.py
@@ -66,6 +66,4 @@ def test_model_initializes_once():
     ):
         doc = layout.DocumentLayout.from_file("sample-docs/layout-parser-paper.pdf")
 
-        # print(f"Call count: {doc.pages[0].detection_model.call_count}")
-        print(type(doc.pages[0].detection_model))
         doc.pages[0].detection_model.initializer.assert_called_once()

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.6-dev2"  # pragma: no cover
+__version__ = "0.5.6-dev3"  # pragma: no cover

--- a/unstructured_inference/models/base.py
+++ b/unstructured_inference/models/base.py
@@ -25,13 +25,21 @@ from unstructured_inference.models.yolox import (
 
 DEFAULT_MODEL = "detectron2_onnx"
 
+models = {}
+
 
 def get_model(model_name: Optional[str] = None) -> UnstructuredModel:
     """Gets the model object by model name."""
     # TODO(alan): These cases are similar enough that we can probably do them all together with
     # importlib
+
+    global models
+
     if model_name is None:
         model_name = DEFAULT_MODEL
+
+    if model_name in models:
+        return models[model_name]
 
     if model_name in DETECTRON2_MODEL_TYPES:
         model: UnstructuredModel = UnstructuredDetectronModel()
@@ -55,6 +63,7 @@ def get_model(model_name: Optional[str] = None) -> UnstructuredModel:
         model.initialize(**CHIPPER_MODEL_TYPES[model_name])
     else:
         raise UnknownModelException(f"Unknown model type: {model_name}")
+    models[model_name] = model
     return model
 
 

--- a/unstructured_inference/models/base.py
+++ b/unstructured_inference/models/base.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Dict, Optional
 
 from unstructured_inference.logger import logger
 from unstructured_inference.models.chipper import MODEL_TYPES as CHIPPER_MODEL_TYPES
@@ -25,7 +25,7 @@ from unstructured_inference.models.yolox import (
 
 DEFAULT_MODEL = "detectron2_onnx"
 
-models = {}
+models: Dict[str, UnstructuredModel] = {}
 
 
 def get_model(model_name: Optional[str] = None) -> UnstructuredModel:


### PR DESCRIPTION
Fixes the memory issue that was discovered in #152.

* Caches named models as they are loaded to prevent reloading or creating multiple copies.
* Adds test that fails if model is initialized more than once (fails on `main`).

This should also address concerns that Chipper was being loaded multiple times @ajjimeno.

#### Testing:

The following code should run without crashing or the memory footprint exploding (takes a long time):
```python
from unstructured_inference.inference.layout import DocumentLayout
DocumentLayout.from_file("sample-docs/pdf2image-memory-error-test-400p.pdf")
```