### PR TITLE
Update os dir naming for images

### DIFF
--- a/test_unstructured_inference/inference/test_layout.py
+++ b/test_unstructured_inference/inference/test_layout.py
@@ -836,7 +836,7 @@ def test_create_image_output_dir():
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp_f_path = os.path.join(tmpdir, "loremipsum.pdf")
         output_dir = create_image_output_dir(tmp_f_path)
-        expected_output_dir = os.path.join(os.path.abspath(tmpdir), "loremipsum")
+        expected_output_dir = os.path.join(os.path.abspath(tmpdir), "loremipsum_images")
         assert os.path.isdir(output_dir)
         assert os.path.isabs(output_dir)
         assert output_dir == expected_output_dir

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -470,6 +470,8 @@ def create_image_output_dir(
     directory path"""
     parent_dir = os.path.abspath(os.path.dirname(filename))
     f_name_without_extension = os.path.splitext(os.path.basename(filename))[0]
-    output_dir = os.path.join(parent_dir, f_name_without_extension)
+
+    # Add a suffix to avoid conflicts in case original file doesn't have an extension
+    output_dir = os.path.join(parent_dir, f"{f_name_without_extension}_images")
     os.makedirs(output_dir, exist_ok=True)
     return output_dir


### PR DESCRIPTION
### Description
Current approach causes issues when a file is passed in without an extension, causing the `os.makedirs` to raise an exception because it tried to create a dir of the same name as an existing file. This appends a suffix to that dir name to avoid such conflicts. 