### PR TITLE
Updated detectron2 repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ install-base-pip-packages:
 
 .PHONY: install-detectron2
 install-detectron2:
-	pip install "detectron2@git+https://github.com/facebookresearch/detectron2.git@a2e43ea#egg=detectron2"
+	pip install "detectron2@git+https://github.com/facebookresearch/detectron2.git@57bdb21249d5418c130d54e2ebdc94dda7a4c01a"
 
 .PHONY: install-paddleocr
 install-paddleocr:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Run `pip install unstructured-inference`.
 but is not automatically installed with this package. 
 For MacOS and Linux, build from source with:
 ```shell
-pip install 'git+https://github.com/facebookresearch/detectron2.git@a2e43ea#egg=detectron2'
+pip install 'git+https://github.com/facebookresearch/detectron2.git@57bdb21249d5418c130d54e2ebdc94dda7a4c01a'
 ```
 Other install options can be found in the 
 [Detectron2 installation guide](https://detectron2.readthedocs.io/en/latest/tutorials/install.html).


### PR DESCRIPTION
This PR updates detectron2 (non-onnx) for using the latest version of the repository since a breaking change was done in Pillow library.

https://github.com/facebookresearch/detectron2/issues/5010