### PR TITLE
fix: handle errors from Tesseract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.5.8
+## 0.5.9-dev0
 
 * Add alternative architecture for detectron2
 * Updates:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.5.8-dev2
+## 0.5.8
 
 * Add alternative architecture for detectron2
 * Updates:
@@ -10,6 +10,7 @@
 | ipython       | 8.12.2    | 8.14.0   |
 
 * Cache named models that have been loaded
+* Handle exceptions from Tesseract
 
 ## 0.5.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.5.9-dev0
+## 0.5.9
 
 * Handle exceptions from Tesseract
 

--- a/test_unstructured_inference/inference/test_layout.py
+++ b/test_unstructured_inference/inference/test_layout.py
@@ -83,6 +83,21 @@ def test_ocr(monkeypatch):
     assert elements.ocr(text_block, image=image) == mock_text
 
 
+def test_ocr_with_error(monkeypatch):
+    class MockOCRAgent:
+        def detect(self, *args):
+            # We sometimes get this error on very small images
+            raise tesseract.TesseractError(-8, "Estimating resolution as 1023")
+
+    monkeypatch.setattr(tesseract, "ocr_agents", {"eng": MockOCRAgent})
+    monkeypatch.setattr(tesseract, "is_pytesseract_available", lambda *args: True)
+
+    image = Image.fromarray(np.random.randint(12, 24, (40, 40)), mode="RGB")
+    text_block = layout.TextRegion(1, 2, 3, 4, text=None)
+
+    assert elements.ocr(text_block, image=image) == ""
+
+
 class MockLayoutModel:
     def __init__(self, layout):
         self.layout_return = layout

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.8"  # pragma: no cover
+__version__ = "0.5.9-dev0"  # pragma: no cover

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.8-dev2"  # pragma: no cover
+__version__ = "0.5.8"  # pragma: no cover

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.9-dev0"  # pragma: no cover
+__version__ = "0.5.9"  # pragma: no cover

--- a/unstructured_inference/inference/elements.py
+++ b/unstructured_inference/inference/elements.py
@@ -269,7 +269,11 @@ def ocr(text_block: TextRegion, image: Image.Image, languages: str = "eng") -> s
     agent = tesseract.ocr_agents.get(languages)
     if agent is None:
         raise RuntimeError("OCR agent is not loaded for {languages}.")
-    return agent.detect(cropped_image)
+
+    try:
+        return agent.detect(cropped_image)
+    except tesseract.TesseractError:
+        return ""
 
 
 def needs_ocr(

--- a/unstructured_inference/models/tesseract.py
+++ b/unstructured_inference/models/tesseract.py
@@ -1,11 +1,13 @@
 from typing import Dict
 
 from layoutparser.ocr.tesseract_agent import TesseractAgent, is_pytesseract_available
-from pytesseract.pytesseract import TesseractError
+import pytesseract
 
 from unstructured_inference.logger import logger
 
 ocr_agents: Dict[str, TesseractAgent] = {}
+
+TesseractError = pytesseract.pytesseract.TesseractError
 
 
 def load_agent(languages: str = "eng"):

--- a/unstructured_inference/models/tesseract.py
+++ b/unstructured_inference/models/tesseract.py
@@ -1,7 +1,7 @@
 from typing import Dict
 
-from layoutparser.ocr.tesseract_agent import TesseractAgent, is_pytesseract_available
 import pytesseract
+from layoutparser.ocr.tesseract_agent import TesseractAgent, is_pytesseract_available
 
 from unstructured_inference.logger import logger
 

--- a/unstructured_inference/models/tesseract.py
+++ b/unstructured_inference/models/tesseract.py
@@ -1,6 +1,7 @@
 from typing import Dict
 
 from layoutparser.ocr.tesseract_agent import TesseractAgent, is_pytesseract_available
+from pytesseract.pytesseract import TesseractError
 
 from unstructured_inference.logger import logger
 


### PR DESCRIPTION
Certain regions of a document are failing ocr with this error:

`pytesseract.pytesseract.TesseractError: (-8, 'Estimating resolution as 1250')` (for some value)

When I try the same region on the CLI, I get:

```
$ tesseract bad_tile.jpeg output
Estimating resolution as 1813
Floating point exception
```

Whatever the root cause, let's catch this error and return an empty string.