### PR TITLE
build: revert default model, cut release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 0.5.8-dev2
+## 0.5.8
 
-* Add alternative architecture for detectron2
+* Add alternative architecture for detectron2 (but default is unchanged)
 * Updates:
 
 | Library       | From      | To       |

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.8-dev2"  # pragma: no cover
+__version__ = "0.5.8"  # pragma: no cover

--- a/unstructured_inference/models/base.py
+++ b/unstructured_inference/models/base.py
@@ -23,7 +23,7 @@ from unstructured_inference.models.yolox import (
     UnstructuredYoloXModel,
 )
 
-DEFAULT_MODEL = "detectron2_mask_rcnn"
+DEFAULT_MODEL = "detectron2_onnx"
 
 models: Dict[str, UnstructuredModel] = {}
 


### PR DESCRIPTION
For reasons not yet entirely clear, using the model introduced in:
https://github.com/Unstructured-IO/unstructured-inference/commit/04b2e6fe5bf9506551714f11ffdbd1abfc28ea13
is causing regressions with how elements are labeled (esp. a lot of `UncategorizedText` vs. `NarrativeText`).

Until that is resolved, keep the old model as the default base model (but this may be overridden, as usual).