### PR TITLE
enhancement: warn if low dpi chipper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.11-dev0
+
+* Add warning when chipper is used with < 300 DPI
+
 ## 0.5.10
 
 * Implement full-page OCR

--- a/test_unstructured_inference/inference/test_layout.py
+++ b/test_unstructured_inference/inference/test_layout.py
@@ -9,6 +9,7 @@ import pytest
 from PIL import Image
 
 import unstructured_inference.models.base as models
+import unstructured_inference.models.chipper as chipper
 from unstructured_inference.inference import elements, layout, layoutelement
 from unstructured_inference.inference.layout import create_image_output_dir
 from unstructured_inference.models import detectron2, tesseract
@@ -866,3 +867,13 @@ def test_create_image_output_dir_no_ext():
         assert os.path.isdir(output_dir)
         assert os.path.isabs(output_dir)
         assert output_dir == expected_output_dir
+
+
+def test_warning_if_chipper_and_low_dpi(caplog):
+    with patch.object(layout.DocumentLayout, "from_file") as mock_from_file, patch.object(
+        chipper.UnstructuredChipperModel, "initialize"
+    ):
+        layout.process_file_with_model("asdf", model_name="chipper", pdf_image_dpi=299)
+        mock_from_file.assert_called_once()
+        assert caplog.records[0].levelname == "WARNING"
+        assert "DPI >= 300" in caplog.records[0].msg

--- a/test_unstructured_inference/inference/test_layout.py
+++ b/test_unstructured_inference/inference/test_layout.py
@@ -9,10 +9,9 @@ import pytest
 from PIL import Image
 
 import unstructured_inference.models.base as models
-import unstructured_inference.models.chipper as chipper
 from unstructured_inference.inference import elements, layout, layoutelement
 from unstructured_inference.inference.layout import create_image_output_dir
-from unstructured_inference.models import detectron2, tesseract
+from unstructured_inference.models import chipper, detectron2, tesseract
 from unstructured_inference.models.unstructuredmodel import (
     UnstructuredElementExtractionModel,
     UnstructuredObjectDetectionModel,
@@ -871,7 +870,8 @@ def test_create_image_output_dir_no_ext():
 
 def test_warning_if_chipper_and_low_dpi(caplog):
     with patch.object(layout.DocumentLayout, "from_file") as mock_from_file, patch.object(
-        chipper.UnstructuredChipperModel, "initialize"
+        chipper.UnstructuredChipperModel,
+        "initialize",
     ):
         layout.process_file_with_model("asdf", model_name="chipper", pdf_image_dpi=299)
         mock_from_file.assert_called_once()

--- a/test_unstructured_inference/models/test_model.py
+++ b/test_unstructured_inference/models/test_model.py
@@ -42,8 +42,9 @@ def test_get_model_warns_on_chipper(monkeypatch, caplog):
         "UnstructuredChipperModel",
         MockModel,
     )
-    models.get_model("chipper")
-    assert caplog.records[0].levelname == "WARNING"
+    with mock.patch.object(models, "models", {}):
+        models.get_model("chipper")
+        assert caplog.records[0].levelname == "WARNING"
 
 
 def test_raises_invalid_model():

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.10"  # pragma: no cover
+__version__ = "0.5.11-dev0"  # pragma: no cover

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -401,6 +401,13 @@ def process_file_with_model(
 ) -> DocumentLayout:
     """Processes pdf file with name filename into a DocumentLayout by using a model identified by
     model_name."""
+
+    if (pdf_image_dpi < 300) and (model_name == "chipper"):
+        logger.warning(
+            "The chipper model performs better when images are rendered with DPI >= 300 "
+            f"(currently {pdf_image_dpi})."
+        )
+
     model = get_model(model_name)
     if isinstance(model, UnstructuredObjectDetectionModel):
         detection_model = model

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -405,7 +405,7 @@ def process_file_with_model(
     if (pdf_image_dpi < 300) and (model_name == "chipper"):
         logger.warning(
             "The chipper model performs better when images are rendered with DPI >= 300 "
-            f"(currently {pdf_image_dpi})."
+            f"(currently {pdf_image_dpi}).",
         )
 
     model = get_model(model_name)

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -404,7 +404,7 @@ def process_file_with_model(
 
     if (pdf_image_dpi < 300) and (model_name == "chipper"):
         logger.warning(
-            "The chipper model performs better when images are rendered with DPI >= 300 "
+            "The Chipper model performs better when images are rendered with DPI >= 300 "
             f"(currently {pdf_image_dpi}).",
         )
 


### PR DESCRIPTION
Chipper is best used when images are rendered at 300 dpi or above. This PR adds a warning if Chipper is used with DPI less than 300.

#### Testing:

Run the following code:
```python
from unstructured_inference.inference.layout import process_file_with_model
process_file_with_model(filename="sample-docs/loremipsum.pdf", model_name="chipper", pdf_image_dpi=299)

```
You should get 2 warnings, the first being that Chipper should be used with DPI >= 300.