### PR TITLE
Fix for wrong type assignation at ingest-test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: 'Unstructured-IO/unstructured'
+        ref: 'feat/plain-text-outputs-for-testing'  
     - name: Checkout this repo
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: 'Unstructured-IO/unstructured'
-        ref: 'feat/plain-text-outputs-for-testing'  
     - name: Checkout this repo
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,7 @@ jobs:
         sudo add-apt-repository -y ppa:alex-p/tesseract-ocr5
         sudo apt-get install -y tesseract-ocr
         sudo apt-get install -y tesseract-ocr-kor
+        sudo apt-get install -y diffstat
         tesseract --version
         make install-ingest-s3
         make install-ingest-azure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.5.18-dev0
+## 0.5.18
 
 * Fix for incorrect type assignation at ingest test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 0.5.11-dev0
+## 0.5.11
 
 * Add warning when chipper is used with < 300 DPI
+* Fix for incorrect type assignation at ingest test
 
 ## 0.5.10
 

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.11-dev0"  # pragma: no cover
+__version__ = "0.5.11"  # pragma: no cover

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.18-dev0"  # pragma: no cover
+__version__ = "0.5.18"  # pragma: no cover

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -28,6 +28,9 @@ from unstructured_inference.inference.layoutelement import (
 from unstructured_inference.inference.ordering import order_layout
 from unstructured_inference.logger import logger
 from unstructured_inference.models.base import get_model
+from unstructured_inference.models.detectron2onnx import (
+    UnstructuredDetectronONNXModel,
+)
 from unstructured_inference.models.unstructuredmodel import (
     UnstructuredElementExtractionModel,
     UnstructuredObjectDetectionModel,
@@ -262,15 +265,33 @@ class PageLayout:
             raise ValueError("Invalid OCR mode")
 
         if self.layout is not None:
+            kwargs = {}
+            # NOTE(Benjamin): With this the thresholds are only changed for detextron2_mask_rcnn
+            # In other case the default values for the functions are used
+            if (
+                isinstance(self.detection_model, UnstructuredDetectronONNXModel)
+                and "R_50" in self.detection_model.model_path
+            ):
+                kwargs = {"same_region_threshold": 0.5, "subregion_threshold": 0.5}
             inferred_layout = merge_inferred_layout_with_extracted_layout(
                 inferred_layout=inferred_layout,
                 extracted_layout=self.layout,
                 ocr_layout=ocr_layout,
+                **kwargs,
             )
         elif ocr_layout is not None:
+            kwargs = {}
+            # NOTE(Benjamin): With this the thresholds are only changed for detextron2_mask_rcnn
+            # In other case the default values for the functions are used
+            if (
+                isinstance(self.detection_model, UnstructuredDetectronONNXModel)
+                and "R_50" in self.detection_model.model_path
+            ):
+                kwargs = {"subregion_threshold": 0.3}
             inferred_layout = merge_inferred_layout_with_ocr_layout(
                 inferred_layout=inferred_layout,
                 ocr_layout=ocr_layout,
+                **kwargs,
             )
 
         elements = self.get_elements_from_layout(cast(List[TextRegion], inferred_layout))

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -270,7 +270,7 @@ class PageLayout:
             # In other case the default values for the functions are used
             if (
                 isinstance(self.detection_model, UnstructuredDetectronONNXModel)
-                and "R_50" in self.detection_model.model_path
+                and "R_50" not in self.detection_model.model_path
             ):
                 threshold_kwargs = {"same_region_threshold": 0.5, "subregion_threshold": 0.5}
             inferred_layout = merge_inferred_layout_with_extracted_layout(
@@ -285,7 +285,7 @@ class PageLayout:
             # In other case the default values for the functions are used
             if (
                 isinstance(self.detection_model, UnstructuredDetectronONNXModel)
-                and "R_50" in self.detection_model.model_path
+                and "R_50" not in self.detection_model.model_path
             ):
                 threshold_kwargs = {"subregion_threshold": 0.3}
             inferred_layout = merge_inferred_layout_with_ocr_layout(

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -265,33 +265,33 @@ class PageLayout:
             raise ValueError("Invalid OCR mode")
 
         if self.layout is not None:
-            kwargs = {}
+            threshold_kwargs = {}
             # NOTE(Benjamin): With this the thresholds are only changed for detextron2_mask_rcnn
             # In other case the default values for the functions are used
             if (
                 isinstance(self.detection_model, UnstructuredDetectronONNXModel)
                 and "R_50" in self.detection_model.model_path
             ):
-                kwargs = {"same_region_threshold": 0.5, "subregion_threshold": 0.5}
+                threshold_kwargs = {"same_region_threshold": 0.5, "subregion_threshold": 0.5}
             inferred_layout = merge_inferred_layout_with_extracted_layout(
                 inferred_layout=inferred_layout,
                 extracted_layout=self.layout,
                 ocr_layout=ocr_layout,
-                **kwargs,
+                **threshold_kwargs,
             )
         elif ocr_layout is not None:
-            kwargs = {}
+            threshold_kwargs = {}
             # NOTE(Benjamin): With this the thresholds are only changed for detextron2_mask_rcnn
             # In other case the default values for the functions are used
             if (
                 isinstance(self.detection_model, UnstructuredDetectronONNXModel)
                 and "R_50" in self.detection_model.model_path
             ):
-                kwargs = {"subregion_threshold": 0.3}
+                threshold_kwargs = {"subregion_threshold": 0.3}
             inferred_layout = merge_inferred_layout_with_ocr_layout(
                 inferred_layout=inferred_layout,
                 ocr_layout=ocr_layout,
-                **kwargs,
+                **threshold_kwargs,
             )
 
         elements = self.get_elements_from_layout(cast(List[TextRegion], inferred_layout))

--- a/unstructured_inference/inference/layoutelement.py
+++ b/unstructured_inference/inference/layoutelement.py
@@ -80,8 +80,8 @@ def merge_inferred_layout_with_extracted_layout(
     inferred_layout: Collection[LayoutElement],
     extracted_layout: Collection[TextRegion],
     ocr_layout: Optional[List[TextRegion]] = None,
-    same_region_threshold: float = 0.50, #0.50
-    subregion_threshold: float = 0.50, #0.50
+    same_region_threshold: float = 0.50,
+    subregion_threshold: float = 0.50,
 ) -> List[LayoutElement]:
     """Merge two layouts to produce a single layout."""
     extracted_elements_to_add: List[TextRegion] = []
@@ -156,7 +156,7 @@ def merge_inferred_layout_with_extracted_layout(
 def merge_inferred_layout_with_ocr_layout(
     inferred_layout: List[LayoutElement],
     ocr_layout: List[TextRegion],
-    subregion_threshold: float = 0.3, #0.3
+    subregion_threshold: float = 0.3,
 ) -> List[LayoutElement]:
     """
     Merge the inferred layout with the OCR-detected text regions.

--- a/unstructured_inference/inference/layoutelement.py
+++ b/unstructured_inference/inference/layoutelement.py
@@ -80,8 +80,8 @@ def merge_inferred_layout_with_extracted_layout(
     inferred_layout: Collection[LayoutElement],
     extracted_layout: Collection[TextRegion],
     ocr_layout: Optional[List[TextRegion]] = None,
-    same_region_threshold: float = 0.75,
-    subregion_threshold: float = 0.75,
+    same_region_threshold: float = 0.50, #0.50
+    subregion_threshold: float = 0.50, #0.50
 ) -> List[LayoutElement]:
     """Merge two layouts to produce a single layout."""
     extracted_elements_to_add: List[TextRegion] = []
@@ -156,7 +156,7 @@ def merge_inferred_layout_with_extracted_layout(
 def merge_inferred_layout_with_ocr_layout(
     inferred_layout: List[LayoutElement],
     ocr_layout: List[TextRegion],
-    subregion_threshold: float = 0.5,
+    subregion_threshold: float = 0.3, #0.3
 ) -> List[LayoutElement]:
     """
     Merge the inferred layout with the OCR-detected text regions.

--- a/unstructured_inference/inference/layoutelement.py
+++ b/unstructured_inference/inference/layoutelement.py
@@ -80,8 +80,8 @@ def merge_inferred_layout_with_extracted_layout(
     inferred_layout: Collection[LayoutElement],
     extracted_layout: Collection[TextRegion],
     ocr_layout: Optional[List[TextRegion]] = None,
-    same_region_threshold: float = 0.50,
-    subregion_threshold: float = 0.50,
+    same_region_threshold: float = 0.75,
+    subregion_threshold: float = 0.75,
 ) -> List[LayoutElement]:
     """Merge two layouts to produce a single layout."""
     extracted_elements_to_add: List[TextRegion] = []
@@ -160,7 +160,7 @@ def merge_inferred_layout_with_extracted_layout(
 def merge_inferred_layout_with_ocr_layout(
     inferred_layout: List[LayoutElement],
     ocr_layout: List[TextRegion],
-    subregion_threshold: float = 0.3,
+    subregion_threshold: float = 0.5,
 ) -> List[LayoutElement]:
     """
     Merge the inferred layout with the OCR-detected text regions.


### PR DESCRIPTION
This PR changes some thresholds for getting the ingest test correct at `unstructured`. 