### PR TITLE
fix: make DPI optional with default None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 0.5.11-dev0
+## 0.5.11
 
 * Add warning when chipper is used with < 300 DPI
+* Use None default for dpi so defaults can be properly handled upstream
 
 ## 0.5.10
 

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.11-dev0"  # pragma: no cover
+__version__ = "0.5.11"  # pragma: no cover

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -367,7 +367,7 @@ def process_data_with_model(
     ocr_mode: str = "entire_page",
     fixed_layouts: Optional[List[Optional[List[TextRegion]]]] = None,
     extract_tables: bool = False,
-    pdf_image_dpi: int = 200,
+    pdf_image_dpi: Optional[int] = None,
 ) -> DocumentLayout:
     """Processes pdf file in the form of a file handler (supporting a read method) into a
     DocumentLayout by using a model identified by model_name."""
@@ -397,11 +397,13 @@ def process_file_with_model(
     ocr_mode: str = "entire_page",
     fixed_layouts: Optional[List[Optional[List[TextRegion]]]] = None,
     extract_tables: bool = False,
-    pdf_image_dpi: int = 200,
+    pdf_image_dpi: Optional[int] = None,
 ) -> DocumentLayout:
     """Processes pdf file with name filename into a DocumentLayout by using a model identified by
     model_name."""
 
+    if pdf_image_dpi is None:
+        pdf_image_dpi = 200
     if (pdf_image_dpi < 300) and (model_name == "chipper"):
         logger.warning(
             "The Chipper model performs better when images are rendered with DPI >= 300 "

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -403,7 +403,7 @@ def process_file_with_model(
     model_name."""
 
     if pdf_image_dpi is None:
-        pdf_image_dpi = 200
+        pdf_image_dpi = 300 if model_name == "chipper" else 200
     if (pdf_image_dpi < 300) and (model_name == "chipper"):
         logger.warning(
             "The Chipper model performs better when images are rendered with DPI >= 300 "


### PR DESCRIPTION
Made `pdf_image_dpi` default `None` to allow for more complex handling upstream.