### PR TITLE
fix: Fix pdfminer error when using process_data_with_model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.12
+
+* Fix a pdfminer error when using `process_data_with_model`
+
 ## 0.5.11
 
 * Add warning when chipper is used with < 300 DPI

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.11"  # pragma: no cover
+__version__ = "0.5.12"  # pragma: no cover

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -373,6 +373,7 @@ def process_data_with_model(
     DocumentLayout by using a model identified by model_name."""
     with tempfile.NamedTemporaryFile() as tmp_file:
         tmp_file.write(data.read())
+        tmp_file.flush()  # Make sure the file is written out
         layout = process_file_with_model(
             tmp_file.name,
             model_name,


### PR DESCRIPTION
When a pdf page doesn't have much data, it may get buffered in the write to a tempfile. If this happens, we'll hit an error reading the file back. Open to suggestions for a way to unit test this - I was creating some test files with pypdf but I couldn't trigger the error.

Steps to verify:
[bad_page.pdf](https://github.com/Unstructured-IO/unstructured-inference/files/12363180/bad_page.pdf)

* With the attached file, run this snippet on main and confirm that there's an exception - `PDFSyntaxError: No /Root object! - Is this really a PDF?`
* Run it on this branch and confirm the error goes away

```
from unstructured_inference.inference.layout import process_data_with_model

filename = "bad_page.pdf"

with open(filename, 'rb') as f:
    process_data_with_model(f, model_name="detectron2_lp")
```