### PR TITLE
fix: use temporary instead of fixed directories for storing images of pdfs being processed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.15-dev0
+
+* Fix to no longer create a directory for storing processed images
+* Hot-load images for annotation
+
 ## 0.5.14
 
 * Add TIFF test file and TIFF filetype to `test_from_image_file` in `test_layout`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 
 * Handle an uncaught TesseractError
 
-
 ## 0.5.14
 
 * Add TIFF test file and TIFF filetype to `test_from_image_file` in `test_layout`

--- a/test_unstructured_inference/inference/test_layout.py
+++ b/test_unstructured_inference/inference/test_layout.py
@@ -396,7 +396,6 @@ def test_from_file(monkeypatch, mock_final_layout):
             page = doc.pages[0]
             assert page.elements[0] == mock_final_layout
             assert page.image_metadata == image_metadata
-            assert page.image_path == image_path
             assert page.image is None
 
 

--- a/test_unstructured_inference/inference/test_layout.py
+++ b/test_unstructured_inference/inference/test_layout.py
@@ -10,7 +10,6 @@ from PIL import Image
 
 import unstructured_inference.models.base as models
 from unstructured_inference.inference import elements, layout, layoutelement
-from unstructured_inference.inference.layout import create_image_output_dir
 from unstructured_inference.models import chipper, detectron2, tesseract
 from unstructured_inference.models.unstructuredmodel import (
     UnstructuredElementExtractionModel,
@@ -384,10 +383,6 @@ def test_from_file(monkeypatch, mock_final_layout):
         }
 
         with patch.object(
-            layout,
-            "create_image_output_dir",
-            return_value=tmpdir,
-        ), patch.object(
             layout,
             "load_pdf",
             lambda *args, **kwargs: ([[]], [image_path]),
@@ -845,26 +840,6 @@ def test_exposed_pdf_image_dpi(pdf_image_dpi, expected, monkeypatch):
     with patch.object(layout.PageLayout, "from_image") as mock_from_image:
         layout.DocumentLayout.from_file("sample-docs/loremipsum.pdf", pdf_image_dpi=pdf_image_dpi)
         assert mock_from_image.call_args[0][0].height == expected
-
-
-def test_create_image_output_dir():
-    with tempfile.TemporaryDirectory() as tmpdir:
-        tmp_f_path = os.path.join(tmpdir, "loremipsum.pdf")
-        output_dir = create_image_output_dir(tmp_f_path)
-        expected_output_dir = os.path.join(os.path.abspath(tmpdir), "loremipsum_images")
-        assert os.path.isdir(output_dir)
-        assert os.path.isabs(output_dir)
-        assert output_dir == expected_output_dir
-
-
-def test_create_image_output_dir_no_ext():
-    with tempfile.TemporaryDirectory() as tmpdir:
-        tmp_f_path = os.path.join(tmpdir, "loremipsum_no_ext")
-        output_dir = create_image_output_dir(tmp_f_path)
-        expected_output_dir = os.path.join(os.path.abspath(tmpdir), "loremipsum_no_ext_images")
-        assert os.path.isdir(output_dir)
-        assert os.path.isabs(output_dir)
-        assert output_dir == expected_output_dir
 
 
 def test_warning_if_chipper_and_low_dpi(caplog):

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.14"  # pragma: no cover
+__version__ = "0.5.15-dev0"  # pragma: no cover

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,2 +1,1 @@
 __version__ = "0.5.16"  # pragma: no cover
-

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -195,7 +195,7 @@ class PageLayout:
         if image_metadata is None:
             image_metadata = {}
         self.image_metadata = image_metadata
-        self.image_path = None
+        self.image_path = image_path
         self.image_array: Union[np.ndarray, None] = None
         self.document_filename = document_filename
         self.layout = layout
@@ -513,7 +513,7 @@ def get_element_from_block(
 def load_pdf(
     filename: str,
     dpi: int = 200,
-    output_folder: Union[str, PurePath] = None,
+    output_folder: Optional[Union[str, PurePath]] = None,
     path_only: bool = False,
 ) -> Tuple[List[List[TextRegion]], Union[List[Image.Image], List[str]]]:
     """Loads the image and word objects from a pdf using pdfplumber and the image renderings of the
@@ -542,12 +542,19 @@ def load_pdf(
     if path_only and not output_folder:
         raise ValueError("output_folder must be specified if path_only is true")
 
-    images = pdf2image.convert_from_path(
-        filename,
-        dpi=dpi,
-        output_folder=output_folder,
-        paths_only=path_only,
-    )
+    if output_folder is not None:
+        images = pdf2image.convert_from_path(
+            filename,
+            dpi=dpi,
+            output_folder=output_folder,
+            paths_only=path_only,
+        )
+    else:
+        images = pdf2image.convert_from_path(
+            filename,
+            dpi=dpi,
+            paths_only=path_only,
+        )
 
     return layouts, images
 

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -542,20 +542,6 @@ def load_pdf(
     return layouts, images
 
 
-def create_image_output_dir(
-    filename: Union[str, PurePath],
-) -> Union[str, PurePath]:
-    """Creates a directory to store the converted images from the pdf pages and returns the
-    directory path"""
-    parent_dir = os.path.abspath(os.path.dirname(filename))
-    f_name_without_extension = os.path.splitext(os.path.basename(filename))[0]
-
-    # Add a suffix to avoid conflicts in case original file doesn't have an extension
-    output_dir = os.path.join(parent_dir, f"{f_name_without_extension}_images")
-    os.makedirs(output_dir, exist_ok=True)
-    return output_dir
-
-
 def parse_ocr_data(ocr_data: dict) -> List[TextRegion]:
     """
     Parse the OCR result data to extract a list of TextRegion objects.

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -303,7 +303,9 @@ class PageLayout:
                 self.image_array = np.array(image)
         return self.image_array
 
-    def annotate(self, colors: Optional[Union[List[str], str]] = None, image_dpi: int = 200) -> Image.Image:
+    def annotate(
+        self, colors: Optional[Union[List[str], str]] = None, image_dpi: int = 200
+    ) -> Image.Image:
         """Annotates the elements on the page image."""
         if colors is None:
             colors = ["red" for _ in self.elements]

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -304,7 +304,9 @@ class PageLayout:
         return self.image_array
 
     def annotate(
-        self, colors: Optional[Union[List[str], str]] = None, image_dpi: int = 200
+        self,
+        colors: Optional[Union[List[str], str]] = None,
+        image_dpi: int = 200,
     ) -> Image.Image:
         """Annotates the elements on the page image."""
         if colors is None:


### PR DESCRIPTION
**Summary**

- Replaces using a created directory for storing image outputs with a temporary directory
- Deprecates `create_image_output_dir` method
- Adds hot-loading for annotating images because images are no longer stored long-term in a directory
- Adds a document_filename keyword arg to the PageLayout to enable hot-loading

**Tests**

Removes tests associated with `create_image_output_dir`