### PR TITLE
sort tokens before use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.23
+
+* use sorted tokens (top down then left to right) in table layout recognition
+
 ## 0.5.22
 
 * Add object-detection classification probabilities to LayoutElement for all currently implemented object detection models

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.22"  # pragma: no cover
+__version__ = "0.5.23"  # pragma: no cover

--- a/unstructured_inference/models/tables.py
+++ b/unstructured_inference/models/tables.py
@@ -120,8 +120,8 @@ class UnstructuredTableTransformerModel(UnstructuredModel):
             outputs_structure = self.model(**encoding)
 
         tokens = self.get_tokens(x=x)
-
-        sorted(tokens, key=lambda x: x["bbox"][1] * 10000 + x["bbox"][0])
+        # sort tokens top down then left to right
+        tokens = sorted(tokens, key=lambda x: x["bbox"][1] * 10000 + x["bbox"][0])
 
         # 'tokens' is a list of tokens
         # Need to be in a relative reading order


### PR DESCRIPTION
This PR changes the logic inside table detection so use sorted tokens as input into `recognize` function. The tokens are sorted top down then left to right. 