### PR TITLE
use tesseract info to assist table structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.24
+
+* use `tesseract` extracted block, line, and word order to assist table structure post processing
+
 ## 0.5.23
 
 * Add functionality to bring back embedded images in PDF

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.23"  # pragma: no cover
+__version__ = "0.5.24"  # pragma: no cover

--- a/unstructured_inference/models/tables.py
+++ b/unstructured_inference/models/tables.py
@@ -109,6 +109,10 @@ class UnstructuredTableTransformerModel(UnstructuredModel):
                         (idtx.top + idtx.height) / zoom,
                     ],
                     "text": idtx.text,
+                    # those information are used to align the rows and columns
+                    "span_num": idtx.word_num,
+                    "line_num": idtx.line_num,
+                    "block_num": idtx.block_num,
                 },
             )
         return tokens
@@ -121,11 +125,9 @@ class UnstructuredTableTransformerModel(UnstructuredModel):
 
         tokens = self.get_tokens(x=x)
 
-        sorted(tokens, key=lambda x: x["bbox"][1] * 10000 + x["bbox"][0])
-
         # 'tokens' is a list of tokens
         # Need to be in a relative reading order
-        # If no order is provided, use current order
+        # If no order is provided by OCR, use current order
         for idx, token in enumerate(tokens):
             if "span_num" not in token:
                 token["span_num"] = idx


### PR DESCRIPTION
## Summary

The table structure post processing code can use OCR software detected block, line, and span order to assist structure detection (by [sorting](https://github.com/Unstructured-IO/unstructured-inference/blob/bdee10268ad056bd3e4313769dcc5a5ef1362155/unstructured_inference/models/table_postprocess.py#L293-L295) the tokens detected by OCR, and this order may not correspond to the order returned by OCR). `tesseract` does provide those information in the table return so this PR adds those data into the `tokens` so they can be utilized in table post processing.

## test

Doesn't seem to change anything yet... this is a small part in the process chain (sorting tokens) so hard to detect if it makes a difference at the moment. More testing might show some difference?
