### PR TITLE
Unset env var after test

### DIFF
--- a/test_unstructured_inference/test_elements.py
+++ b/test_unstructured_inference/test_elements.py
@@ -198,3 +198,5 @@ def test_ocr_paddle(monkeypatch, caplog):
     with caplog.at_level(logging.INFO):
         _ = elements.ocr(text_block, image, languages="en")
         assert "paddle" in caplog.text
+
+    monkeypatch.delenv("ENTIRE_PAGE_OCR")


### PR DESCRIPTION
Testing if unsetting this env var after test gets rid of the paddle errors in tests