### PR TITLE
feat: make table transformer parameters configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.2
+
+* move the confidence threshold for table transformer to config
+
 ## 0.6.1
 
 * YoloX_quantized is now the default model. This models detects most diverse types and detect tables better than previous model.

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.6.1"  # pragma: no cover
+__version__ = "0.6.2"  # pragma: no cover

--- a/unstructured_inference/config.py
+++ b/unstructured_inference/config.py
@@ -47,6 +47,42 @@ class InferenceConfig:
         return self._get_int("TABLE_IMAGE_BACKGROUND_PAD", 0)
 
     @property
+    def TT_TABLE_CONF(self) -> float:
+        """confidence threshold for table identified by table transformer"""
+        return self._get_float("TT_TABLE_CONF", 0.5)
+
+    @property
+    def TABLE_COLUMN_CONF(self) -> float:
+        """confidence threshold for column identified by table transformer"""
+        return self._get_float("TABLE_COLUMN_CONF", 0.5)
+
+    @property
+    def TABLE_ROW_CONF(self) -> float:
+        """confidence threshold for column identified by table transformer"""
+        return self._get_float("TABLE_ROW_CONF", 0.5)
+
+    @property
+    def TABLE_COLUMN_HEADER_CONF(self) -> float:
+        """confidence threshold for column header identified by table transformer"""
+        return self._get_float("TABLE_COLUMN_HEADER_CONF", 0.5)
+
+    @property
+    def TABLE_PROJECTED_ROW_HEADER_CONF(self) -> float:
+        """confidence threshold for projected row header identified by table transformer"""
+        return self._get_float("TABLE_PROJECTED_ROW_HEADER_CONF", 0.5)
+
+    @property
+    def TABLE_SPANNING_CELL_CONF(self) -> float:
+        """confidence threshold for table spanning cells identified by table transformer"""
+        return self._get_float("TABLE_SPANNING_CELL_CONF", 0.5)
+
+    @property
+    def TABLE_IOB_THRESHOLD(self) -> float:
+        """minimum intersection over box area ratio for a box to be considered part of a larger box
+        it intersects"""
+        return self._get_float("TABLE_IOB_THRESHOLD", 0.5)
+
+    @property
     def LAYOUT_SAME_REGION_THRESHOLD(self) -> float:
         """threshold for two layouts' bounding boxes to be considered as the same region
 


### PR DESCRIPTION
- refactor `tables.py` so that the structure element confidence threshold values are loaded from `inference_config`
- refactor intersection over box area threshold in `objects_to_structure` to config intead of using hardwired value of 0.5 (default is still 0.5)