### PR TITLE
fix: padded boxes are not rescaled/shifted correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.3
+
+* fix a bug where padded table structure bounding boxes are not shifted back into the original image coordinates correctly
+
 ## 0.6.2
 
 * move the confidence threshold for table transformer to config
@@ -5,8 +9,8 @@
 ## 0.6.1
 
 * YoloX_quantized is now the default model. This models detects most diverse types and detect tables better than previous model.
-* Since detection models tend to nest elements inside others(specifically in Tables), an algorithm has been added for reducing this 
-  behavior. Now all the elements produced by detection models are disjoint and they don't produce overlapping regions, which helps 
+* Since detection models tend to nest elements inside others(specifically in Tables), an algorithm has been added for reducing this
+  behavior. Now all the elements produced by detection models are disjoint and they don't produce overlapping regions, which helps
   reduce duplicated content.
 * Add `source` property to our elements, so you can know where the information was generated (OCR or detection model)
 

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.6.2"  # pragma: no cover
+__version__ = "0.6.3"  # pragma: no cover

--- a/unstructured_inference/models/tables.py
+++ b/unstructured_inference/models/tables.py
@@ -203,6 +203,9 @@ def recognize(outputs: dict, img: Image, tokens: list, out_html: bool = False):
     tables_structure = objects_to_structures(objects, tokens, str_class_thresholds)
     # Enumerate all table cells: grid cells and spanning cells
     tables_cells = [structure_to_cells(structure, tokens)[0] for structure in tables_structure]
+    import pdb
+
+    pdb.set_trace()
 
     # Convert cells to HTML
     if out_html:
@@ -220,11 +223,11 @@ def outputs_to_objects(outputs, img_size, class_idx2name):
     pred_bboxes = outputs["pred_boxes"].detach().cpu()[0]
 
     pad = outputs.get("pad_for_structure_detection", 0)
-    scale_size = (img_size[0] + pad, img_size[1] + pad)
+    scale_size = (img_size[0] + pad * 2, img_size[1] + pad * 2)
     pred_bboxes = [elem.tolist() for elem in rescale_bboxes(pred_bboxes, scale_size)]
     # unshift the padding; padding effectively shifted the bounding boxes of structures in the
     # original image with half of the total pad
-    shift_size = pad / 2
+    shift_size = pad
 
     objects = []
     for label, score, bbox in zip(pred_labels, pred_scores, pred_bboxes):

--- a/unstructured_inference/models/tables.py
+++ b/unstructured_inference/models/tables.py
@@ -203,9 +203,6 @@ def recognize(outputs: dict, img: Image, tokens: list, out_html: bool = False):
     tables_structure = objects_to_structures(objects, tokens, str_class_thresholds)
     # Enumerate all table cells: grid cells and spanning cells
     tables_cells = [structure_to_cells(structure, tokens)[0] for structure in tables_structure]
-    import pdb
-
-    pdb.set_trace()
 
     # Convert cells to HTML
     if out_html:


### PR DESCRIPTION
- fix a bug where after padding for table transformer the detected table structure bounding boxes were not scaled or shifted correctly
- this bug can cause mis-alignment of table structure and OCR contents if padding is used
- this changeset also adds a (unit-ish) test to ensure padding is processed correctly in table transformer