### PR TITLE
Feat/download quantized model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.1
+
+* Download yolox_quantized from HF
+
 ## 0.7.0
 
 * Remove all OCR related code expect the table OCR code

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -3,7 +3,8 @@ python-multipart
 huggingface-hub
 opencv-python!=4.7.0.68
 onnx==1.14.1
-onnxruntime
+# NOTE(benjamin): Pinned because onnxruntime changed the way quantization is done, and we need to update our code to support it
+onnxruntime<1.16
 # NOTE(alan): Pinned because this is when the most recent module we import appeared
 transformers>=4.25.1
 rapidfuzz

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,9 +8,9 @@ antlr4-python3-runtime==4.9.3
     # via omegaconf
 certifi==2023.7.22
     # via requests
-cffi==1.15.1
+cffi==1.16.0
     # via cryptography
-charset-normalizer==3.2.0
+charset-normalizer==3.3.0
     # via
     #   pdfminer-six
     #   requests
@@ -20,7 +20,7 @@ contourpy==1.1.1
     # via matplotlib
 cryptography==41.0.4
     # via pdfminer-six
-cycler==0.11.0
+cycler==0.12.0
     # via matplotlib
 effdet==0.4.1
     # via layoutparser
@@ -31,14 +31,17 @@ filelock==3.12.4
     #   transformers
 flatbuffers==23.5.26
     # via onnxruntime
-fonttools==4.42.1
+fonttools==4.43.0
     # via matplotlib
-fsspec==2023.9.1
-    # via huggingface-hub
-huggingface-hub==0.17.2
+fsspec==2023.9.2
+    # via
+    #   huggingface-hub
+    #   torch
+huggingface-hub==0.16.4
     # via
     #   -r requirements/base.in
     #   timm
+    #   tokenizers
     #   transformers
 humanfriendly==10.0
     # via coloredlogs
@@ -79,13 +82,13 @@ omegaconf==2.3.0
     # via effdet
 onnx==1.14.1
     # via -r requirements/base.in
-onnxruntime==1.16.0
+onnxruntime==1.15.1
     # via -r requirements/base.in
-opencv-python==4.8.0.76
+opencv-python==4.8.1.78
     # via
     #   -r requirements/base.in
     #   layoutparser
-packaging==23.1
+packaging==23.2
     # via
     #   huggingface-hub
     #   matplotlib
@@ -110,7 +113,7 @@ pillow==10.0.1
     #   torchvision
 portalocker==2.8.2
     # via iopath
-protobuf==4.24.3
+protobuf==4.24.4
     # via
     #   onnx
     #   onnxruntime
@@ -139,9 +142,9 @@ pyyaml==6.0.1
     #   omegaconf
     #   timm
     #   transformers
-rapidfuzz==3.3.0
+rapidfuzz==3.3.1
     # via -r requirements/base.in
-regex==2023.8.8
+regex==2023.10.3
     # via transformers
 requests==2.31.0
     # via
@@ -162,15 +165,15 @@ sympy==1.12
     #   torch
 timm==0.9.7
     # via effdet
-tokenizers==0.13.3
+tokenizers==0.14.0
     # via transformers
-torch==2.0.1
+torch==2.1.0
     # via
     #   effdet
     #   layoutparser
     #   timm
     #   torchvision
-torchvision==0.15.2
+torchvision==0.16.0
     # via
     #   effdet
     #   layoutparser
@@ -180,7 +183,7 @@ tqdm==4.66.1
     #   huggingface-hub
     #   iopath
     #   transformers
-transformers==4.33.2
+transformers==4.34.0
     # via -r requirements/base.in
 typing-extensions==4.8.0
     # via
@@ -190,7 +193,7 @@ typing-extensions==4.8.0
     #   torch
 tzdata==2023.3
     # via pandas
-urllib3==2.0.5
+urllib3==2.0.6
     # via requests
 zipp==3.17.0
     # via importlib-resources

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -16,7 +16,7 @@ argon2-cffi==23.1.0
     # via jupyter-server
 argon2-cffi-bindings==21.2.0
     # via argon2-cffi
-arrow==1.2.3
+arrow==1.3.0
     # via isoduration
 asttokens==2.4.0
     # via stack-data
@@ -26,7 +26,7 @@ attrs==23.1.0
     # via
     #   jsonschema
     #   referencing
-babel==2.12.1
+babel==2.13.0
     # via jupyterlab-server
 backcall==0.2.0
     # via ipython
@@ -41,11 +41,11 @@ certifi==2023.7.22
     #   -c requirements/base.txt
     #   -c requirements/test.txt
     #   requests
-cffi==1.15.1
+cffi==1.16.0
     # via
     #   -c requirements/base.txt
     #   argon2-cffi-bindings
-charset-normalizer==3.2.0
+charset-normalizer==3.3.0
     # via
     #   -c requirements/base.txt
     #   -c requirements/test.txt
@@ -62,7 +62,7 @@ contourpy==1.1.1
     # via
     #   -c requirements/base.txt
     #   matplotlib
-cycler==0.11.0
+cycler==0.12.0
     # via
     #   -c requirements/base.txt
     #   matplotlib
@@ -76,11 +76,11 @@ exceptiongroup==1.1.3
     # via
     #   -c requirements/test.txt
     #   anyio
-executing==1.2.0
+executing==2.0.0
     # via stack-data
-fastjsonschema==2.18.0
+fastjsonschema==2.18.1
     # via nbformat
-fonttools==4.42.1
+fonttools==4.43.0
     # via
     #   -c requirements/base.txt
     #   matplotlib
@@ -114,7 +114,7 @@ ipykernel==6.25.2
     #   jupyter-console
     #   jupyterlab
     #   qtconsole
-ipython==8.12.2
+ipython==8.12.3
     # via
     #   -r requirements/dev.in
     #   ipykernel
@@ -126,7 +126,7 @@ ipywidgets==8.1.1
     # via jupyter
 isoduration==20.11.0
     # via jsonschema
-jedi==0.19.0
+jedi==0.19.1
     # via ipython
 jinja2==3.1.2
     # via
@@ -157,7 +157,7 @@ jupyter-client==8.3.1
     #   qtconsole
 jupyter-console==6.6.3
     # via jupyter
-jupyter-core==5.3.1
+jupyter-core==5.3.2
     # via
     #   ipykernel
     #   jupyter-client
@@ -208,11 +208,11 @@ matplotlib-inline==0.1.6
     # via
     #   ipykernel
     #   ipython
-mistune==3.0.1
+mistune==3.0.2
     # via nbconvert
 nbclient==0.8.0
     # via nbconvert
-nbconvert==7.8.0
+nbconvert==7.9.2
     # via
     #   jupyter
     #   jupyter-server
@@ -236,7 +236,7 @@ numpy==1.24.4
     #   matplotlib
 overrides==7.4.0
     # via jupyter-server
-packaging==23.1
+packaging==23.2
     # via
     #   -c requirements/base.txt
     #   -c requirements/test.txt
@@ -266,7 +266,7 @@ pip-tools==7.3.0
     # via -r requirements/dev.in
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-platformdirs==3.10.0
+platformdirs==3.11.0
     # via
     #   -c requirements/test.txt
     #   jupyter-core
@@ -346,7 +346,7 @@ rfc3986-validator==0.1.1
     # via
     #   jsonschema
     #   jupyter-events
-rpds-py==0.10.3
+rpds-py==0.10.4
     # via
     #   jsonschema
     #   referencing
@@ -365,7 +365,7 @@ sniffio==1.3.0
     #   anyio
 soupsieve==2.5
     # via beautifulsoup4
-stack-data==0.6.2
+stack-data==0.6.3
     # via ipython
 terminado==0.17.1
     # via
@@ -388,7 +388,7 @@ tornado==6.3.3
     #   jupyterlab
     #   notebook
     #   terminado
-traitlets==5.10.0
+traitlets==5.11.2
     # via
     #   comm
     #   ipykernel
@@ -405,6 +405,8 @@ traitlets==5.10.0
     #   nbconvert
     #   nbformat
     #   qtconsole
+types-python-dateutil==2.8.19.14
+    # via arrow
 typing-extensions==4.8.0
     # via
     #   -c requirements/base.txt
@@ -413,12 +415,12 @@ typing-extensions==4.8.0
     #   ipython
 uri-template==1.3.0
     # via jsonschema
-urllib3==2.0.5
+urllib3==2.0.6
     # via
     #   -c requirements/base.txt
     #   -c requirements/test.txt
     #   requests
-wcwidth==0.2.6
+wcwidth==0.2.8
     # via prompt-toolkit
 webcolors==1.13
     # via jsonschema

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -14,7 +14,7 @@ certifi==2023.7.22
     #   httpcore
     #   httpx
     #   requests
-charset-normalizer==3.2.0
+charset-normalizer==3.3.0
     # via
     #   -c requirements/base.txt
     #   requests
@@ -22,7 +22,7 @@ click==8.1.7
     # via
     #   -r requirements/test.in
     #   black
-coverage[toml]==7.3.1
+coverage[toml]==7.3.2
     # via
     #   -r requirements/test.in
     #   pytest-cov
@@ -40,7 +40,7 @@ flake8==6.1.0
     #   flake8-docstrings
 flake8-docstrings==1.7.0
     # via -r requirements/test.in
-fsspec==2023.9.1
+fsspec==2023.9.2
     # via
     #   -c requirements/base.txt
     #   huggingface-hub
@@ -50,7 +50,7 @@ httpcore==0.18.0
     # via httpx
 httpx==0.25.0
     # via -r requirements/test.in
-huggingface-hub==0.17.2
+huggingface-hub==0.16.4
     # via
     #   -c requirements/base.txt
     #   -r requirements/test.in
@@ -70,7 +70,7 @@ mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
-packaging==23.1
+packaging==23.2
     # via
     #   -c requirements/base.txt
     #   black
@@ -86,7 +86,7 @@ pillow==10.0.1
     # via
     #   -c requirements/base.txt
     #   pdf2image
-platformdirs==3.10.0
+platformdirs==3.11.0
     # via black
 pluggy==1.3.0
     # via pytest
@@ -112,7 +112,7 @@ requests==2.31.0
     # via
     #   -c requirements/base.txt
     #   huggingface-hub
-ruff==0.0.290
+ruff==0.0.292
     # via -r requirements/test.in
 sniffio==1.3.0
     # via
@@ -137,7 +137,7 @@ typing-extensions==4.8.0
     #   black
     #   huggingface-hub
     #   mypy
-urllib3==2.0.5
+urllib3==2.0.6
     # via
     #   -c requirements/base.txt
     #   requests

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.0"  # pragma: no cover
+__version__ = "0.7.1"  # pragma: no cover


### PR DESCRIPTION
After this PR is merged two main changes will be done:

* `onnxruntime` will be pinned to be <1.16 due some changes in quantization recently introduced not being compatible for the moment with the library and model.
*  yolox_quantized will be downloaded from HF instead being generated at runtime.

In order to test you can execute:
```
from unstructured_inference.inference import layout
from unstructured_inference.models.base import get_model

file = "sample-docs/example_table.jpg"
model = get_model("yolox_quantized")
doc = layout.DocumentLayout.from_image_file(
    file,
    model,
    supplement_with_ocr_elements=True,
    ocr_strategy="never",
)
```

And should show a download from HF downloading a file called `yolox_l0.05_quantized.onnx`