### PR TITLE
Fix: sort elements extracted by `pdfminer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.2
+
+* Sort elements extracted by `pdfminer` to get consistent result from `aggregate_by_block()`
+
 ## 0.7.1
 
 * Download yolox_quantized from HF

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.1
+
+* sort elements extracted by `pdfminer` to get consistent result from `aggregate_by_block()`
+
 ## 0.7.0
 
 * Remove all OCR related code expect the table OCR code

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.0"  # pragma: no cover
+__version__ = "0.7.1"  # pragma: no cover

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.1"  # pragma: no cover
+__version__ = "0.7.2"  # pragma: no cover

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -570,6 +570,8 @@ def load_pdf(
 
             if text_region.area > 0:
                 layout.append(text_region)
+
+        layout = order_layout(layout)
         layouts.append(layout)
 
     if path_only and not output_folder:


### PR DESCRIPTION
### Summary
- sort elements extracted by `pdfminer` to get consistent results from `aggregate_by_block()`
### Testing
PDF: [recalibrating-risk-report_4-4.pdf](https://github.com/Unstructured-IO/unstructured-inference/files/12835342/recalibrating-risk-report_4-4.pdf)

```
f_path = "dist/docs/recalibrating-risk-report_4-4.pdf"

layout = process_file_with_model(
    filename=f_path,
    model_name=None,
)

elements = layout.pages[0].elements
print("\n\n".join([str(el) for el in elements]))
print(len(elements))
```