### PR TITLE
enhancement: remove control characters from text in all layout elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.3-dev0
+
+* Remove control characters from the text of all layout elements
+
 ## 0.7.2
 
 * Sort elements extracted by `pdfminer` to get consistent result from `aggregate_by_block()`

--- a/test_unstructured_inference/inference/test_layout.py
+++ b/test_unstructured_inference/inference/test_layout.py
@@ -381,7 +381,7 @@ def test_from_file_fixed_layout(fixed_layouts, called_method, not_called_method)
 
 @pytest.mark.parametrize(
     ("text", "expected"),
-    [("a\ts\x0cd\nfas\fd\rf\b", "asdfasdf"), ("\"'\\", "\"'\\")],
+    [("c\to\x0cn\ftrol\ncharacter\rs\b", "control characters"), ("\"'\\", "\"'\\")],
 )
 def test_remove_control_characters(text, expected):
     assert elements.remove_control_characters(text) == expected

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.2"  # pragma: no cover
+__version__ = "0.7.3-dev0"  # pragma: no cover

--- a/unstructured_inference/inference/elements.py
+++ b/unstructured_inference/inference/elements.py
@@ -214,6 +214,7 @@ class TextRegion(Rectangle):
             text = aggregate_by_block(self, objects)
         else:
             text = ""
+        text = remove_control_characters(text)
         return text
 
 
@@ -253,7 +254,6 @@ def aggregate_by_block(
     block."""
     filtered_blocks = [obj for obj in pdf_objects if obj.is_in(text_region, error_margin=5)]
     text = " ".join([x.text for x in filtered_blocks if x.text])
-    text = remove_control_characters(text)
     return text
 
 

--- a/unstructured_inference/inference/elements.py
+++ b/unstructured_inference/inference/elements.py
@@ -214,8 +214,8 @@ class TextRegion(Rectangle):
             text = aggregate_by_block(self, objects)
         else:
             text = ""
-        text = remove_control_characters(text)
-        return text
+        cleaned_text = remove_control_characters(text)
+        return cleaned_text
 
 
 class EmbeddedTextRegion(TextRegion):
@@ -276,6 +276,10 @@ def is_cid_present(text: str) -> bool:
 
 def remove_control_characters(text: str) -> str:
     """Removes control characters from text."""
+
+    # Replace newline character with a space
+    text = text.replace("\n", " ")
+    # Remove other control characters
     out_text = "".join(c for c in text if unicodedata.category(c)[0] != "C")
     return out_text
 


### PR DESCRIPTION
Currently, the `unstructured-inference` library removes control characters only from text filled by [aggregate_by_block()](https://github.com/Unstructured-IO/unstructured-inference/blob/ffb1f0b/unstructured_inference/inference/elements.py#L256). This PR is intended to remove control characters from the text of all layout elements to get clearer text. 
This PR also fixes an issue of words being concatenated together when there are spaces (e.g. `features Data` vs. `featuresData`) produced after performing OCR refactoring (attached image).
![unknown_002](https://github.com/Unstructured-IO/unstructured-inference/assets/9475974/880e2403-c534-4a0d-9d4b-4c5a66ea26c8)

### Summary
- remove control characters from text in all layout elements
- update `remove_control_characters()` to replace a newline character with a space
### Testing
PDF: [main.PMC6312790_2-2.pdf](https://github.com/Unstructured-IO/unstructured-inference/files/12851045/main.PMC6312790_2-2.pdf)
```
layout = process_file_with_model(
    filename="main.PMC6312790_2-2.pdf",
    model_name=None,
)

elements = layout.pages[0].elements
print("\n\n".join([str(el) for el in elements]))
```