### PR TITLE
chore: chipper model name should point to latest chipper version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.7.3-dev2
+## 0.7.3-dev3
 
 * Integration of Chipperv2 and additional Chipper functionality, which includes automatic detection of GPU,
 bounding box prediction and hierarchical representation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.7.3-dev3
+## 0.7.3
 
 * Integration of Chipperv2 and additional Chipper functionality, which includes automatic detection of GPU,
 bounding box prediction and hierarchical representation.

--- a/test_unstructured_inference/models/test_chippermodel.py
+++ b/test_unstructured_inference/models/test_chippermodel.py
@@ -237,7 +237,7 @@ def test_postprocess_bbox(decoded_str, expected_classes):
 
 
 def test_run_chipper_v2():
-    model = get_model("chipperv2")
+    model = get_model("chipper")
     img = Image.open("sample-docs/easy_table.jpg")
     elements = model(img)
     tables = [el for el in elements if el.type == "Table"]

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.3-dev2"  # pragma: no cover
+__version__ = "0.7.3-dev3"  # pragma: no cover

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.3-dev3"  # pragma: no cover
+__version__ = "0.7.3"  # pragma: no cover

--- a/unstructured_inference/constants.py
+++ b/unstructured_inference/constants.py
@@ -12,6 +12,7 @@ class Source(Enum):
     DETECTRON2_LP = "detectron2_lp"
     CHIPPER = "chipper"
     CHIPPERV1 = "chipperv1"
+    CHIPPERV2 = "chipperv2"
     PDFMINER = "pdfminer"
     MERGED = "merged"
 

--- a/unstructured_inference/constants.py
+++ b/unstructured_inference/constants.py
@@ -11,7 +11,7 @@ class Source(Enum):
     DETECTRON2_ONNX = "detectron2_onnx"
     DETECTRON2_LP = "detectron2_lp"
     CHIPPER = "chipper"
-    CHIPPERV2 = "chipperv2"
+    CHIPPERV1 = "chipperv1"
     PDFMINER = "pdfminer"
     MERGED = "merged"
 

--- a/unstructured_inference/models/chipper.py
+++ b/unstructured_inference/models/chipper.py
@@ -26,7 +26,7 @@ MODEL_TYPES: Dict[Optional[str], Union[LazyDict, dict]] = {
         "max_length": 1200,
         "heatmap_h": 52,
         "heatmap_w": 39,
-        "source": Source.CHIPPER,
+        "source": Source.CHIPPERV1,
     },
     "chipper": {
         "pre_trained_model_repo": "unstructuredio/chipper-fast-fine-tuning",
@@ -37,7 +37,7 @@ MODEL_TYPES: Dict[Optional[str], Union[LazyDict, dict]] = {
         "max_length": 1536,
         "heatmap_h": 40,
         "heatmap_w": 30,
-        "source": Source.CHIPPERV2,
+        "source": Source.CHIPPER,
     },
 }
 
@@ -309,7 +309,7 @@ class UnstructuredChipperModel(UnstructuredElementExtractionModel):
         min_text_size: int = 15,
     ) -> List[LayoutElement]:
         """For chipper, remove elements from other sources."""
-        return [el for el in elements if el.source in (Source.CHIPPER, Source.CHIPPERV2)]
+        return [el for el in elements if el.source in (Source.CHIPPER, Source.CHIPPERV1)]
 
     def adjust_bbox(self, bbox, x_offset, y_offset, ratio, target_size):
         """Translate bbox by (x_offset, y_offset) and shrink by ratio."""

--- a/unstructured_inference/models/chipper.py
+++ b/unstructured_inference/models/chipper.py
@@ -18,7 +18,7 @@ from unstructured_inference.models.unstructuredmodel import UnstructuredElementE
 from unstructured_inference.utils import LazyDict
 
 MODEL_TYPES: Dict[Optional[str], Union[LazyDict, dict]] = {
-    "chipper": {
+    "chipperv1": {
         "pre_trained_model_repo": "unstructuredio/ved-fine-tuning",
         "swap_head": False,
         "start_token_prefix": "<s_",
@@ -28,7 +28,7 @@ MODEL_TYPES: Dict[Optional[str], Union[LazyDict, dict]] = {
         "heatmap_w": 39,
         "source": Source.CHIPPER,
     },
-    "chipperv2": {
+    "chipper": {
         "pre_trained_model_repo": "unstructuredio/chipper-fast-fine-tuning",
         "swap_head": True,
         "swap_head_hidden_layer_size": 128,

--- a/unstructured_inference/models/chipper.py
+++ b/unstructured_inference/models/chipper.py
@@ -28,7 +28,7 @@ MODEL_TYPES: Dict[Optional[str], Union[LazyDict, dict]] = {
         "heatmap_w": 39,
         "source": Source.CHIPPERV1,
     },
-    "chipper": {
+    "chipperv2": {
         "pre_trained_model_repo": "unstructuredio/chipper-fast-fine-tuning",
         "swap_head": True,
         "swap_head_hidden_layer_size": 128,
@@ -40,6 +40,8 @@ MODEL_TYPES: Dict[Optional[str], Union[LazyDict, dict]] = {
         "source": Source.CHIPPER,
     },
 }
+
+MODEL_TYPES["chipper"] = MODEL_TYPES["chipperv2"]
 
 
 class UnstructuredChipperModel(UnstructuredElementExtractionModel):


### PR DESCRIPTION
Update model names so that `"chipper"` points to latest version of Chipper, while `"chipperv1"` points to old version.