### PR TITLE
fix(deps): add onnx as base requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.6
+
+* Fix: include onnx as base dependency.
+
 ## 0.7.5
 
 * Improved packaging

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -3,6 +3,7 @@ layoutparser[layoutmodels,tesseract]
 python-multipart
 huggingface-hub
 opencv-python!=4.7.0.68
+onnx
 # NOTE(benjamin): Pinned because onnxruntime changed the way quantization is done, and we need to update our code to support it
 onnxruntime<1.16
 # NOTE(alan): Pinned because this is when the most recent module we import appeared

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -71,6 +71,7 @@ numpy==1.23.0
     #   contourpy
     #   layoutparser
     #   matplotlib
+    #   onnx
     #   onnxruntime
     #   opencv-python
     #   pandas
@@ -80,6 +81,8 @@ numpy==1.23.0
     #   transformers
 omegaconf==2.3.0
     # via effdet
+onnx==1.14.1
+    # via -r requirements/base.in
 onnxruntime==1.15.1
     # via -r requirements/base.in
 opencv-python==4.8.1.78
@@ -112,7 +115,9 @@ pillow==10.0.1
 portalocker==2.8.2
     # via iopath
 protobuf==4.24.4
-    # via onnxruntime
+    # via
+    #   onnx
+    #   onnxruntime
 pycocotools==2.0.7
     # via effdet
 pycparser==2.21
@@ -185,6 +190,7 @@ typing-extensions==4.8.0
     # via
     #   huggingface-hub
     #   iopath
+    #   onnx
     #   torch
 tzdata==2023.3
     # via pandas

--- a/requirements/sg.txt
+++ b/requirements/sg.txt
@@ -145,6 +145,7 @@ omegaconf==2.3.0
     #   super-gradients
 onnx==1.13.0
     # via
+    #   -c requirements/base.in
     #   onnx-simplifier
     #   super-gradients
 onnx-simplifier==0.4.33

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.5"  # pragma: no cover
+__version__ = "0.7.6"  # pragma: no cover


### PR DESCRIPTION
`onnx` is required as an explicit dep for unstructured-inference -- it's not pulled in by `onnxruntime`.
As discovered when bumping to unstructured-inference==0.7.5 in [this unstructured commit](https://github.com/Unstructured-IO/unstructured/pull/1756/commits/1878da0f0d1c83c9f2c9efee2de6ae7d0cf437f5).