### PR TITLE
fix: invalid zoom lead to cv2 error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.6
+
+* fix a bug where invalid zoom factor lead to exceptions; now invalid zoom factors results in no scaling of the image
+
 ## 0.7.5
 
 * Improved packaging

--- a/test_unstructured_inference/models/test_tables.py
+++ b/test_unstructured_inference/models/test_tables.py
@@ -605,6 +605,17 @@ def test_auto_zoom(mocker):
     assert spy.call_count == 1
 
 
+@pytest.mark.parametrize("zoom", [1, 0.1, 5, -1, 0])
+def test_zoom_image(example_image, zoom):
+    width, height = example_image.size
+    new_image = tables.zoom_image(example_image, zoom)
+    new_w, new_h = new_image.size
+    if zoom <= 0:
+        zoom = 1
+    assert new_w == np.round(width * zoom, 0)
+    assert new_h == np.round(height * zoom, 0)
+
+
 def test_padded_results_has_right_dimensions(table_transformer, example_image):
     str_class_name2idx = tables.get_class_map("structure")
     # a simpler mapping so we keep all structure in the returned objs below for test

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.5"  # pragma: no cover
+__version__ = "0.7.6"  # pragma: no cover

--- a/unstructured_inference/models/tables.py
+++ b/unstructured_inference/models/tables.py
@@ -719,6 +719,9 @@ def cells_to_html(cells):
 def zoom_image(image: Image, zoom: float) -> Image:
     """scale an image based on the zoom factor using cv2; the scaled image is post processed by
     dilation then erosion to improve edge sharpness for OCR tasks"""
+    if zoom <= 0:
+        # no zoom but still does dilation and erosion
+        zoom = 1
     new_image = cv2.resize(
         cv2.cvtColor(np.array(image), cv2.COLOR_RGB2BGR),
         None,


### PR DESCRIPTION
- fix a bug where zoom factor <= 0 raises an exception at runtime
- now zoom factor <=0 will result in no scaling of the image

Related report from user: https://unstructuredw-kbe4326.slack.com/archives/C044N0YV08G/p1697456659162509

Test:
This PR adds a unit test with cases where zoom factor is 0 or -1. Without this fix the same error the user reported shows up:
```
error: (-215:Assertion failed) inv_scale_x > 0 in function 'resize'
```