### PR TITLE
fix: memory leak on chipper processor, beam search parameters, and bbox bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.7.7
+
+• Fix a memory leak in DonutProcessor when using large images in numpy format
+• Set the right settings for beam search size > 1
+• Fix a bug that in very rare cases made the last element predicted by Chipper to have a bbox = None
+
 ## 0.7.6
 
 * fix a bug where invalid zoom factor lead to exceptions; now invalid zoom factors results in no scaling of the image

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.6"  # pragma: no cover
+__version__ = "0.7.7"  # pragma: no cover

--- a/unstructured_inference/models/chipper.py
+++ b/unstructured_inference/models/chipper.py
@@ -138,7 +138,6 @@ class UnstructuredChipperModel(UnstructuredElementExtractionModel):
         """Do inference using the wrapped model."""
         tokens, decoder_cross_attentions = self.predict_tokens(image)
         elements = self.postprocess(image, tokens, decoder_cross_attentions)
-        print(elements)
         return elements
 
     def predict_tokens(
@@ -147,7 +146,6 @@ class UnstructuredChipperModel(UnstructuredElementExtractionModel):
     ) -> Tuple[List[int], Sequence[Sequence[torch.Tensor]]]:
         """Predict tokens from image."""
         transformers.set_seed(42)
-        print("page")
         with torch.no_grad():
             encoder_outputs = self.model.encoder(
                 self.processor(

--- a/unstructured_inference/models/chipper.py
+++ b/unstructured_inference/models/chipper.py
@@ -138,6 +138,7 @@ class UnstructuredChipperModel(UnstructuredElementExtractionModel):
         """Do inference using the wrapped model."""
         tokens, decoder_cross_attentions = self.predict_tokens(image)
         elements = self.postprocess(image, tokens, decoder_cross_attentions)
+        print(elements)
         return elements
 
     def predict_tokens(
@@ -146,13 +147,11 @@ class UnstructuredChipperModel(UnstructuredElementExtractionModel):
     ) -> Tuple[List[int], Sequence[Sequence[torch.Tensor]]]:
         """Predict tokens from image."""
         transformers.set_seed(42)
+        print("page")
         with torch.no_grad():
             encoder_outputs = self.model.encoder(
                 self.processor(
-                    np.array(
-                        image,
-                        np.float32,
-                    ),
+                    image,
                     return_tensors="pt",
                 ).pixel_values.to(self.device),
             )
@@ -177,9 +176,9 @@ class UnstructuredChipperModel(UnstructuredElementExtractionModel):
                     encoder_outputs=encoder_outputs,
                     input_ids=self.input_ids,
                     logits_processor=self.logits_processor,
-                    do_sample=False,
+                    do_sample=True,
                     no_repeat_ngram_size=0,
-                    num_beams=5,
+                    num_beams=3,
                     return_dict_in_generate=True,
                     output_attentions=True,
                     output_scores=True,
@@ -304,7 +303,7 @@ class UnstructuredChipperModel(UnstructuredElementExtractionModel):
                 end = i
 
         # If exited before eos is achieved
-        if start != -1 and start < end and len(parents) > 0:
+        if start != -1 and start <= end and len(parents) > 0:
             slicing_end = end + 1
             string = self.tokenizer.decode(output_ids[start:slicing_end])
 


### PR DESCRIPTION
This PR intends to solve the following issues:

* Memory leak in DonutProcessor when using large images in numpy format
* Use the right settings for beam search size > 1
* Solve a bug that in very rare cases made the last element predicted by Chipper to have a bbox = None