### PR TITLE
Fix/no order chipper elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.10-dev0
+
+* fix: Skips ordering elements coming from Chipper
+
 ## 0.7.9
 
 * Allow table model to accept optional OCR tokens

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.9"  # pragma: no cover
+__version__ = "0.7.10-dev0"  # pragma: no cover

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -253,8 +253,9 @@ class PageLayout:
 
         else:
             merged_layout = inferred_layout
-
-        order_elements = isinstance(self.detection_model, UnstructuredChipperModel)
+        # If the model is a chipper model, we don't want to order the
+        # elements, as they are already ordered
+        order_elements = not isinstance(self.detection_model, UnstructuredChipperModel)
         elements = self.get_elements_from_layout(
             cast(List[TextRegion], merged_layout),
             order_elements=order_elements,

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -25,6 +25,7 @@ from unstructured_inference.inference.ordering import order_layout
 from unstructured_inference.inference.pdf import get_images_from_pdf_element
 from unstructured_inference.logger import logger
 from unstructured_inference.models.base import get_model
+from unstructured_inference.models.chipper import UnstructuredChipperModel
 from unstructured_inference.models.detectron2onnx import (
     UnstructuredDetectronONNXModel,
 )
@@ -253,7 +254,11 @@ class PageLayout:
         else:
             merged_layout = inferred_layout
 
-        elements = self.get_elements_from_layout(cast(List[TextRegion], merged_layout))
+        order_elements = isinstance(self.detection_model, UnstructuredChipperModel)
+        elements = self.get_elements_from_layout(
+            cast(List[TextRegion], merged_layout),
+            order_elements=order_elements,
+        )
 
         if self.analysis:
             self.inferred_layout = inferred_layout
@@ -264,10 +269,15 @@ class PageLayout:
 
         return elements
 
-    def get_elements_from_layout(self, layout: List[TextRegion]) -> List[LayoutElement]:
+    def get_elements_from_layout(
+        self,
+        layout: List[TextRegion],
+        order_elements: bool = True,
+    ) -> List[LayoutElement]:
         """Uses the given Layout to separate the page text into elements, either extracting the
         text from the discovered layout blocks."""
-        layout = order_layout(layout)
+        if order_elements:
+            layout = order_layout(layout)
         elements = [
             get_element_from_block(
                 block=e,


### PR DESCRIPTION
This code can't be executed with the current version of `unstructured-inference` due a lack of coordinates on Picture elements produced by Chipper. 
However, those elements shouldn't be ordered at all, so the fix is to skip ordering when Chipper is used.

After this PR is merged this code is correctly executed.

```
from unstructured_inference.inference import layout
from unstructured_inference.models.base import get_model

file = "sample-docs/recalibrating-risk-report.pdf"
model = get_model("chipperv1")
doc = layout.DocumentLayout.from_file(
    file,
    model,
)

print(doc)
```


