### PR TITLE
fix:excess transfer parameters are not processed

### DIFF
--- a/unstructured_inference/models/chipper.py
+++ b/unstructured_inference/models/chipper.py
@@ -63,6 +63,7 @@ class UnstructuredChipperModel(UnstructuredElementExtractionModel):
         no_repeat_ngram_size: int = 10,
         auth_token: Optional[str] = os.environ.get("UNSTRUCTURED_HF_TOKEN"),
         device: Optional[str] = None,
+        **kwargs,
     ):
         """Load the model for inference."""
         if device is None:

--- a/unstructured_inference/models/detectron2.py
+++ b/unstructured_inference/models/detectron2.py
@@ -77,6 +77,7 @@ class UnstructuredDetectronModel(UnstructuredObjectDetectionModel):
         label_map: Optional[Dict[int, str]] = None,
         extra_config: Optional[list] = None,
         device: Optional[str] = None,
+        **kwargs,
     ):
         """Loads the detectron2 model using the specified parameters"""
 

--- a/unstructured_inference/models/detectron2onnx.py
+++ b/unstructured_inference/models/detectron2onnx.py
@@ -95,6 +95,7 @@ class UnstructuredDetectronONNXModel(UnstructuredObjectDetectionModel):
         model_path: str,
         label_map: Dict[int, str],
         confidence_threshold: Optional[float] = None,
+        **kwargs,
     ):
         """Loads the detectron2 model using the specified parameters"""
         if not os.path.exists(model_path) and "detectron2_quantized" in model_path:

--- a/unstructured_inference/models/super_gradients.py
+++ b/unstructured_inference/models/super_gradients.py
@@ -38,6 +38,7 @@ class UnstructuredSuperGradients(UnstructuredObjectDetectionModel):
         model_path: str,
         dataset_yaml_path: str,
         callback: Callable[[np.ndarray, "_sgmodels.sg_module.SgModule"], "sv.Detections"],
+        **kwargs,
     ):
         """Start inference session for SuperGradients model."""
 

--- a/unstructured_inference/models/yolox.py
+++ b/unstructured_inference/models/yolox.py
@@ -64,7 +64,7 @@ class UnstructuredYoloXModel(UnstructuredObjectDetectionModel):
         super().predict(x)
         return self.image_processing(x)
 
-    def initialize(self, model_path: str, label_map: dict):
+    def initialize(self, model_path: str, label_map: dict, **kwargs):
         """Start inference session for YoloX model."""
         self.model_path = model_path
         self.model = onnxruntime.InferenceSession(


### PR DESCRIPTION
### description
The unexpected keyword argument problem is caused by the fact that the subclass of the UnstructuredModel class overrides the initialize method without processing the extra parameters.
The problem occurs in #265,
The same problem occurs in https://github.com/langchain-ai/langchain/issues/12010