### PR TITLE
Feat/chipper gpu float16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.11-dev0
+
+* fix: use automatic mixed precision on GPU for Chipper
+
 ## 0.7.10
 
 * Handle kwargs explicitly when needed, suppress otherwise

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.10"  # pragma: no cover
+__version__ = "0.7.11-dev0"  # pragma: no cover

--- a/unstructured_inference/models/chipper.py
+++ b/unstructured_inference/models/chipper.py
@@ -134,6 +134,7 @@ class UnstructuredChipperModel(UnstructuredElementExtractionModel):
         self.tokens_stop = [self.tokenizer.eos_token_id, self.tokenizer.pad_token_id]
 
         self.model.to(self.device)
+
         self.model.eval()
 
     def predict(self, image) -> List[LayoutElement]:
@@ -150,7 +151,9 @@ class UnstructuredChipperModel(UnstructuredElementExtractionModel):
         transformers.set_seed(42)
         with torch.no_grad():
             amp: Union[TextIO, ContextManager[None]] = (
-                torch.cpu.amp.autocast() if platform.machine() == "x86_64" else nullcontext()
+                torch.cuda.amp.autocast()
+                if self.device == "cuda"
+                else (torch.cpu.amp.autocast() if platform.machine() == "x86_64" else nullcontext())
             )
             with amp:
                 encoder_outputs = self.model.encoder(


### PR DESCRIPTION
We added the automatic mixed precision for CPU, but this is needed as well for GPU running. This PR makes this possible for GPU. 

For testing, probably before and after the change on any long page.

```
from unstructured_inference.inference.layout import DocumentLayout
from unstructured_inference.models.base import get_model

model = get_model("chipper")
doc = DocumentLayout.from_file("sample-docs/layout-parser-paper.pdf",
                               detection_model=model, pdf_image_dpi=300)
```
