### PR TITLE
Feat/field to store inner elements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: 'Unstructured-IO/unstructured'
+        ref: 'benjamin/feat/clean-by-store-pdfminer-inner-elements'
     - name: Checkout this repo
       uses: actions/checkout@v4
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.11-dev0
+
+* enhacement: added field to LayoutElement to store elements inside them
+
 ## 0.7.10
 
 * Handle kwargs explicitly when needed, suppress otherwise

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 0.7.11-dev0
+## 0.7.11
 
-* enhacement: added field to LayoutElement to store elements inside them
+* enhacement: added functionality to remove  nested elements from tables when using detection models + pdfminer, also
+add a field to LayoutElement to store this nested elements
 
 ## 0.7.10
 

--- a/test_unstructured_inference/inference/test_processing_elements.py
+++ b/test_unstructured_inference/inference/test_processing_elements.py
@@ -1,0 +1,80 @@
+import pytest
+
+from unstructured_inference.constants import Source
+from unstructured_inference.inference.elements import Rectangle
+from unstructured_inference.inference.layout import DocumentLayout, LayoutElement, PageLayout
+
+# A set of elements with pdfminer elements inside tables
+deletable_elements_inside_table = [
+    LayoutElement(
+        bbox=Rectangle(0, 0, 100, 100),
+        text="Table with inner elements",
+        type="Table",
+    ),
+    LayoutElement(bbox=Rectangle(50, 50, 70, 70), text="text1", source=Source.PDFMINER),
+    LayoutElement(bbox=Rectangle(70, 70, 80, 80), text="text2", source=Source.PDFMINER),
+]
+
+# A set of elements without pdfminer elements inside
+# tables (no elements with source=Source.PDFMINER)
+no_deletable_elements_inside_table = [
+    LayoutElement(
+        bbox=Rectangle(0, 0, 100, 100),
+        text="Table with inner elements",
+        type="Table",
+        source=Source.YOLOX,
+    ),
+    LayoutElement(bbox=Rectangle(50, 50, 70, 70), text="text1", source=Source.YOLOX),
+    LayoutElement(bbox=Rectangle(70, 70, 80, 80), text="text2", source=Source.YOLOX),
+]
+# A set of elements with pdfminer elements inside tables and other
+# elements with source=Source.PDFMINER
+# Note: there is some elements with source=Source.PDFMINER are not inside tables
+mix_elements_inside_table = [
+    LayoutElement(
+        bbox=Rectangle(0, 0, 100, 100),
+        text="Table1 with inner elements",
+        type="Table",
+        source=Source.YOLOX,
+    ),
+    LayoutElement(bbox=Rectangle(50, 50, 70, 70), text="Inside table1"),
+    LayoutElement(bbox=Rectangle(70, 70, 80, 80), text="Inside table1", source=Source.PDFMINER),
+    LayoutElement(
+        bbox=Rectangle(150, 150, 170, 170),
+        text="Outside tables",
+        source=Source.PDFMINER,
+    ),
+    LayoutElement(
+        bbox=Rectangle(180, 180, 200, 200),
+        text="Outside tables",
+        source=Source.PDFMINER,
+    ),
+    LayoutElement(
+        bbox=Rectangle(0, 500, 100, 700),
+        text="Table2 with inner elements",
+        type="Table",
+        source=Source.YOLOX,
+    ),
+    LayoutElement(bbox=Rectangle(0, 510, 50, 300), text="Inside table2", source=Source.PDFMINER),
+    LayoutElement(bbox=Rectangle(0, 550, 70, 400), text="Inside table2", source=Source.PDFMINER),
+]
+
+
+@pytest.mark.parametrize(
+    ("elements", "lenght_extra_info", "expected_document_lenght"),
+    [
+        (deletable_elements_inside_table, 1, 1),
+        (no_deletable_elements_inside_table, 0, 3),
+        (mix_elements_inside_table, 2, 5),
+    ],
+)
+def test_clean_pdfminer_inner_elements(elements, lenght_extra_info, expected_document_lenght):
+    # create a sample document with pdfminer elements inside tables
+    page = PageLayout(number=1, image=None, layout=elements)
+    page.elements = elements
+    document_with_table = DocumentLayout(pages=[page])
+
+    # call the function to clean the pdfminer inner elements
+    document_with_table.clean_pdfminer_inner_elements()
+
+    assert len(document_with_table.pages[0].elements) == expected_document_lenght

--- a/test_unstructured_inference/inference/test_processing_elements.py
+++ b/test_unstructured_inference/inference/test_processing_elements.py
@@ -61,14 +61,14 @@ mix_elements_inside_table = [
 
 
 @pytest.mark.parametrize(
-    ("elements", "lenght_extra_info", "expected_document_lenght"),
+    ("elements", "length_extra_info", "expected_document_length"),
     [
         (deletable_elements_inside_table, 1, 1),
         (no_deletable_elements_inside_table, 0, 3),
         (mix_elements_inside_table, 2, 5),
     ],
 )
-def test_clean_pdfminer_inner_elements(elements, lenght_extra_info, expected_document_lenght):
+def test_clean_pdfminer_inner_elements(elements, length_extra_info, expected_document_length):
     # create a sample document with pdfminer elements inside tables
     page = PageLayout(number=1, image=None, layout=elements)
     page.elements = elements

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.11-dev0"  # pragma: no cover
+__version__ = "0.7.11"  # pragma: no cover

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.10"  # pragma: no cover
+__version__ = "0.7.11-dev0"  # pragma: no cover

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -160,7 +160,9 @@ class DocumentLayout:
             tables = [e for e in page.elements if e.type == "Table"]
             for i, element in enumerate(page.elements):
                 if element.source == Source.PDFMINER:
-                    element_inside_table = [element.bbox.is_in(t.bbox) for t in tables]
+                    element_inside_table = [
+                        element.bbox.is_in(t.bbox, error_margin=15) for t in tables
+                    ]
                     if sum(element_inside_table) == 1:
                         parent_table_index = element_inside_table.index(True)
                         parent_table = tables[parent_table_index]

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -153,6 +153,21 @@ class DocumentLayout:
             pages.append(page)
         return cls.from_pages(pages)
 
+    def clean_pdfminer_inner_elements(self):
+        """Clean pdfminer elements from inside tables and stores them in pdfminer_inner_text
+        property of the elements"""
+        for page in self.pages:
+            tables = [e for e in page.elements if e.type == "Table"]
+            for i, element in enumerate(page.elements):
+                if element.source == Source.PDFMINER:
+                    element_inside_table = [element.bbox.is_in(t.bbox) for t in tables]
+                    if sum(element_inside_table) == 1:
+                        parent_table_index = element_inside_table.index(True)
+                        parent_table = tables[parent_table_index]
+                        parent_table.pdfminer_inner_text.append(element)
+                        page.elements[i] = None
+            page.elements = [e for e in page.elements if e]
+
 
 class PageLayout:
     """Class for an individual PDF page."""

--- a/unstructured_inference/inference/layoutelement.py
+++ b/unstructured_inference/inference/layoutelement.py
@@ -30,7 +30,7 @@ class LayoutElement(TextRegion):
     prob: Optional[float] = None
     image_path: Optional[str] = None
     parent: Optional[LayoutElement] = None
-    pdfminer_inner_text: List = field(default_factory=list)
+    pdfminer_inner_text: List[LayoutElement] = field(default_factory=list)
 
     def extract_text(
         self,

--- a/unstructured_inference/inference/layoutelement.py
+++ b/unstructured_inference/inference/layoutelement.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Collection, List, Optional
 
 import numpy as np
@@ -30,6 +30,7 @@ class LayoutElement(TextRegion):
     prob: Optional[float] = None
     image_path: Optional[str] = None
     parent: Optional[LayoutElement] = None
+    pdfminer_inner_text: List = field(default_factory=list)
 
     def extract_text(
         self,

--- a/unstructured_inference/models/base.py
+++ b/unstructured_inference/models/base.py
@@ -52,7 +52,7 @@ def get_model(model_name: Optional[str] = None, **kwargs) -> UnstructuredModel:
         initialize_params = {**DETECTRON2_ONNX_MODEL_TYPES[model_name], **kwargs}
     elif model_name in YOLOX_MODEL_TYPES:
         model = UnstructuredYoloXModel()
-        initialize_params = {**YOLOX_MODEL_TYPES[model_name], **kwargs}
+        initialize_params = {**YOLOX_MODEL_TYPES[model_name]}
     elif model_name in CHIPPER_MODEL_TYPES:
         logger.warning(
             "The Chipper model is currently in Beta and is not yet ready for production use. "
@@ -63,7 +63,7 @@ def get_model(model_name: Optional[str] = None, **kwargs) -> UnstructuredModel:
             "zt-1x7cgo0pg-PTptXWylzPQF9xZolzCnwQ",
         )
         model = UnstructuredChipperModel()
-        initialize_params = {**CHIPPER_MODEL_TYPES[model_name], **kwargs}
+        initialize_params = {**CHIPPER_MODEL_TYPES[model_name]}
     elif model_name == "super_gradients":
         model = UnstructuredSuperGradients()
         initialize_params = {**kwargs}


### PR DESCRIPTION
This PR introduces `clean_pdfminer_inner_elements` , which deletes pdfminer elements inside other detection origins such as YoloX or detectron.
This function returns the clean document and stores nested elements inside `pdfminer_inner_text`

The best way to check that this function is working properly is checking the new test test_clean_pdfminer_inner_elements in test_unstructured_inference/inference/test_processing_elements.py

Also, the new ingest-tests will reflect the deletion of the nested elements.
