### PR TITLE
build: update ingest installation invocation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,17 +135,7 @@ jobs:
         sudo apt-get install -y tesseract-ocr-kor
         sudo apt-get install -y diffstat
         tesseract --version
-        make install-ingest-s3
-        make install-ingest-azure
-        make install-ingest-discord
-        make install-ingest-elasticsearch
-        make install-ingest-dropbox
-        make install-ingest-gcs
-        make install-ingest-google-drive
-        make install-ingest-github
-        make install-ingest-gitlab
-        make install-ingest-slack
-        make install-ingest-wikipedia
+        make install-all-ingest
         # only run ingest tests that check expected output diffs.
         bash inference/scripts/test-unstructured-ingest-helper.sh
 


### PR DESCRIPTION
The make targets from `unstructured` used to install extras are no longer functional (need to be updated or removed). This PR updates `unstructured-inference` CI to use a working make target from `unstructured`.

#### Testing:

Ingest test CI should succeed.