### PR TITLE
chore: change the default model to yolox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.12
+
+* change the default model to yolox, as table output appears to be better and speed is similar to `yolox_quantized`
+
 ## 0.7.11
 
 * chore: remove logger info for chipper since its private

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.11"  # pragma: no cover
+__version__ = "0.7.12"  # pragma: no cover

--- a/unstructured_inference/models/base.py
+++ b/unstructured_inference/models/base.py
@@ -25,7 +25,7 @@ from unstructured_inference.models.yolox import (
     UnstructuredYoloXModel,
 )
 
-DEFAULT_MODEL = "yolox_quantized"
+DEFAULT_MODEL = "yolox"
 
 models: Dict[str, UnstructuredModel] = {}
 


### PR DESCRIPTION
The `yolox` model appears to perform better on tables.