### PR TITLE
enhancement: better error message on image/page extraction mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 0.7.11-dev0
+## 0.7.11-dev1
 
+* enhancement: Improve error message when # images extracted doesn't match # page layouts.
 * fix: use automatic mixed precision on GPU for Chipper
 
 ## 0.7.10
@@ -7,7 +8,7 @@
 * Handle kwargs explicitly when needed, suppress otherwise
 * fix: Reduce Chipper memory consumption on x86_64 cpus
 * fix: Skips ordering elements coming from Chipper
-* fix: After refactoring to introduce Chipper, annotate() weren't able to show text with extra info from elements, this is fixed now.
+* fix: After refactoring to introduce Chipper, annotate() wasn't able to show text with extra info from elements, this is fixed now.
 * feat: add table cell and dataframe output formats to table transformer's `run_prediction` call
 * breaking change: function `unstructured_inference.models.tables.recognize` no longer takes `out_html` parameter and it now only returns table cell data format (lists of dictionaries)
 

--- a/test_unstructured_inference/inference/test_layout.py
+++ b/test_unstructured_inference/inference/test_layout.py
@@ -346,7 +346,7 @@ def test_from_file_raises_on_length_mismatch(monkeypatch):
     monkeypatch.setattr(layout, "load_pdf", lambda *args, **kwargs: ([None, None], []))
     with pytest.raises(RuntimeError) as e:
         layout.DocumentLayout.from_file("fake_file")
-    assert "poppler" in str(e).lower()
+    assert "images" in str(e).lower()
 
 
 @pytest.mark.parametrize("idx", range(2))

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.11-dev0"  # pragma: no cover
+__version__ = "0.7.11-dev1"  # pragma: no cover

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -89,7 +89,8 @@ class DocumentLayout:
             if len(layouts) > len(image_paths):
                 raise RuntimeError(
                     "Some images were not loaded. "
-                    "Check that poppler is installed and in your $PATH.",
+                    f"Number of extracted images ({len(image_paths)}) does not match number of "
+                    f"extracted page layouts ({len(layouts)})",
                 )
 
             pages: List[PageLayout] = []


### PR DESCRIPTION
Removed the reference to Poppler in error message when number of images extracted doesn't match the number of page layouts extracted (I'm no longer confident that this is caused by Poppler not being installed). Also provided some details in the message about how many of each were extracted, and updated the test associated with this error.

#### Testing:

Updated CI test should pass.