### PR TITLE
chore: remove logger info for chipper since its private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.7.11-dev3
 
-* fix: remove logger info for chipper
+* chore: remove logger info for chipper since its private
 * fix: update broken slack invite link in chipper logger info
 * enhancement: Improve error message when # images extracted doesn't match # page layouts.
 * fix: use automatic mixed precision on GPU for Chipper

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 0.7.11-dev2
+## 0.7.11-dev3
 
+* fix: remove logger info for chipper
 * fix: update broken slack invite link in chipper logger info
 * enhancement: Improve error message when # images extracted doesn't match # page layouts.
 * fix: use automatic mixed precision on GPU for Chipper

--- a/test_unstructured_inference/models/test_model.py
+++ b/test_unstructured_inference/models/test_model.py
@@ -35,17 +35,6 @@ def test_get_model(monkeypatch):
     assert isinstance(models.get_model("checkbox"), MockModel)
 
 
-def test_get_model_warns_on_chipper(monkeypatch, caplog):
-    monkeypatch.setattr(
-        models,
-        "UnstructuredChipperModel",
-        MockModel,
-    )
-    with mock.patch.object(models, "models", {}):
-        models.get_model("chipper")
-        assert caplog.records[0].levelname == "WARNING"
-
-
 def test_raises_invalid_model():
     with pytest.raises(models.UnknownModelException):
         models.get_model("fake_model")

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.11-dev2"  # pragma: no cover
+__version__ = "0.7.11-dev3"  # pragma: no cover

--- a/unstructured_inference/models/base.py
+++ b/unstructured_inference/models/base.py
@@ -1,6 +1,5 @@
 from typing import Dict, Optional
 
-from unstructured_inference.logger import logger
 from unstructured_inference.models.chipper import MODEL_TYPES as CHIPPER_MODEL_TYPES
 from unstructured_inference.models.chipper import UnstructuredChipperModel
 from unstructured_inference.models.detectron2 import (

--- a/unstructured_inference/models/base.py
+++ b/unstructured_inference/models/base.py
@@ -54,13 +54,6 @@ def get_model(model_name: Optional[str] = None, **kwargs) -> UnstructuredModel:
         model = UnstructuredYoloXModel()
         initialize_params = {**YOLOX_MODEL_TYPES[model_name], **kwargs}
     elif model_name in CHIPPER_MODEL_TYPES:
-        logger.warning(
-            "The Chipper model is currently in Beta and is not yet ready for production use. "
-            "You can reach out to the Unstructured engineering team in the Unstructured "
-            "community Slack if you have any feedback on the Chipper model. "
-            "You can join the community Slack here: "
-            "https://short.unstructured.io/pzw05l7",
-        )
         model = UnstructuredChipperModel()
         initialize_params = {**CHIPPER_MODEL_TYPES[model_name], **kwargs}
     elif model_name == "super_gradients":


### PR DESCRIPTION
Remove the logger info that user won't be able to see since chipper is only available in host API.