### PR TITLE
Jj/warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.12-dev0
+
+* chore: supress UserWarning about specified model providers
+
 ## 0.7.11
 
 * chore: remove logger info for chipper since its private

--- a/test_unstructured_inference/inference/test_layout.py
+++ b/test_unstructured_inference/inference/test_layout.py
@@ -222,6 +222,7 @@ def test_process_file_no_warnings(monkeypatch, mock_final_layout, recwarn):
     monkeypatch.setattr(models.UnstructuredDetectronModel, "initialize", mock_initialize)
     filename = ""
     layout.process_file_with_model(filename, model_name=None)
+    # There should be no UserWarning, but if there is one it should not have the following message
     with pytest.raises(AssertionError, match="not found in warning list"):
         user_warning = recwarn.pop(UserWarning)
         assert "not in available provider names" not in str(user_warning.message)

--- a/test_unstructured_inference/inference/test_layout.py
+++ b/test_unstructured_inference/inference/test_layout.py
@@ -3,7 +3,6 @@ import os.path
 import tempfile
 from functools import partial
 from unittest.mock import ANY, mock_open, patch
-import warnings
 
 import numpy as np
 import pytest

--- a/test_unstructured_inference/inference/test_layout.py
+++ b/test_unstructured_inference/inference/test_layout.py
@@ -222,11 +222,9 @@ def test_process_file_no_warnings(monkeypatch, mock_final_layout, recwarn):
     monkeypatch.setattr(models.UnstructuredDetectronModel, "initialize", mock_initialize)
     filename = ""
     layout.process_file_with_model(filename, model_name=None)
-    try:
+    with pytest.raises(AssertionError, match="not found in warning list"):
         user_warning = recwarn.pop(UserWarning)
         assert "not in available provider names" not in str(user_warning.message)
-    except AssertionError as e:
-        assert "not found in warning list" in str(e)
 
 
 def test_process_file_with_model_raises_on_invalid_model_name():

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.11"  # pragma: no cover
+__version__ = "0.7.12-dev0"  # pragma: no cover

--- a/unstructured_inference/models/detectron2onnx.py
+++ b/unstructured_inference/models/detectron2onnx.py
@@ -6,8 +6,8 @@ import numpy as np
 import onnxruntime
 from huggingface_hub import hf_hub_download
 from huggingface_hub.constants import HUGGINGFACE_HUB_CACHE
-from onnxruntime.quantization import QuantType, quantize_dynamic
 from onnxruntime.capi import _pybind_state as C
+from onnxruntime.quantization import QuantType, quantize_dynamic
 from PIL import Image
 
 from unstructured_inference.constants import Source
@@ -105,11 +105,11 @@ class UnstructuredDetectronONNXModel(UnstructuredObjectDetectionModel):
             quantize_dynamic(source_path, model_path, weight_type=QuantType.QUInt8)
 
         available_providers = C.get_available_providers()
-        ordered_providers=[
-                "TensorrtExecutionProvider",
-                "CUDAExecutionProvider",
-                "CPUExecutionProvider",
-            ]
+        ordered_providers = [
+            "TensorrtExecutionProvider",
+            "CUDAExecutionProvider",
+            "CPUExecutionProvider",
+        ]
         providers = [provider for provider in ordered_providers if provider in available_providers]
 
         self.model = onnxruntime.InferenceSession(

--- a/unstructured_inference/models/detectron2onnx.py
+++ b/unstructured_inference/models/detectron2onnx.py
@@ -7,6 +7,7 @@ import onnxruntime
 from huggingface_hub import hf_hub_download
 from huggingface_hub.constants import HUGGINGFACE_HUB_CACHE
 from onnxruntime.quantization import QuantType, quantize_dynamic
+from onnxruntime.capi import _pybind_state as C
 from PIL import Image
 
 from unstructured_inference.constants import Source
@@ -89,6 +90,7 @@ class UnstructuredDetectronONNXModel(UnstructuredObjectDetectionModel):
         regions = self.postprocess(bboxes, labels, confidence_scores, input_w, input_h)
 
         return regions
+    
 
     def initialize(
         self,
@@ -103,13 +105,17 @@ class UnstructuredDetectronONNXModel(UnstructuredObjectDetectionModel):
             source_path = MODEL_TYPES["detectron2_onnx"]["model_path"]
             quantize_dynamic(source_path, model_path, weight_type=QuantType.QUInt8)
 
-        self.model = onnxruntime.InferenceSession(
-            model_path,
-            providers=[
+        available_providers = C.get_available_providers()
+        ordered_providers=[
                 "TensorrtExecutionProvider",
                 "CUDAExecutionProvider",
                 "CPUExecutionProvider",
-            ],
+            ]
+        providers = [provider for provider in ordered_providers if provider in available_providers]
+
+        self.model = onnxruntime.InferenceSession(
+            model_path,
+            providers=providers,
         )
         self.model_path = model_path
         self.label_map = label_map

--- a/unstructured_inference/models/detectron2onnx.py
+++ b/unstructured_inference/models/detectron2onnx.py
@@ -90,7 +90,6 @@ class UnstructuredDetectronONNXModel(UnstructuredObjectDetectionModel):
         regions = self.postprocess(bboxes, labels, confidence_scores, input_w, input_h)
 
         return regions
-    
 
     def initialize(
         self,

--- a/unstructured_inference/models/yolox.py
+++ b/unstructured_inference/models/yolox.py
@@ -70,11 +70,11 @@ class UnstructuredYoloXModel(UnstructuredObjectDetectionModel):
         self.model_path = model_path
 
         available_providers = C.get_available_providers()
-        ordered_providers=[
-                "TensorrtExecutionProvider",
-                "CUDAExecutionProvider",
-                "CPUExecutionProvider",
-            ]
+        ordered_providers = [
+            "TensorrtExecutionProvider",
+            "CUDAExecutionProvider",
+            "CPUExecutionProvider",
+        ]
         providers = [provider for provider in ordered_providers if provider in available_providers]
 
         self.model = onnxruntime.InferenceSession(

--- a/unstructured_inference/models/yolox.py
+++ b/unstructured_inference/models/yolox.py
@@ -9,6 +9,7 @@ import cv2
 import numpy as np
 import onnxruntime
 from huggingface_hub import hf_hub_download
+from onnxruntime.capi import _pybind_state as C
 from PIL import Image
 
 from unstructured_inference.constants import Source
@@ -67,13 +68,18 @@ class UnstructuredYoloXModel(UnstructuredObjectDetectionModel):
     def initialize(self, model_path: str, label_map: dict):
         """Start inference session for YoloX model."""
         self.model_path = model_path
-        self.model = onnxruntime.InferenceSession(
-            model_path,
-            providers=[
+
+        available_providers = C.get_available_providers()
+        ordered_providers=[
                 "TensorrtExecutionProvider",
                 "CUDAExecutionProvider",
                 "CPUExecutionProvider",
-            ],
+            ]
+        providers = [provider for provider in ordered_providers if provider in available_providers]
+
+        self.model = onnxruntime.InferenceSession(
+            model_path,
+            providers=providers,
         )
 
         self.layout_classes = label_map


### PR DESCRIPTION
Closes #281 

### Summary
Introduces check to see what model providers are available locally before making an InferenceSession call. Providers are kept in order of preference.