### PR TITLE
Chore: UnstructuredTableTransformerModel inherit the init function from UnstructuredModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 0.7.13-dev0
+## 0.7.13
 
+* don't override init function for UnstructuredTableTransformerModel so that it will has field "model"
 * chore: supress UserWarning about specified model providers
 
 ## 0.7.12

--- a/test_unstructured_inference/models/test_tables.py
+++ b/test_unstructured_inference/models/test_tables.py
@@ -40,6 +40,11 @@ def test_load_table_model_raises_when_not_available(model_path):
         table_model.initialize(model=model_path)
 
 
+def test_table_model_inherit_init():
+    table_model = tables.UnstructuredTableTransformerModel()
+    assert hasattr(table_model, "model")
+    assert table_model.model == None
+
 @pytest.mark.parametrize(
     "model_path",
     [

--- a/test_unstructured_inference/models/test_tables.py
+++ b/test_unstructured_inference/models/test_tables.py
@@ -43,7 +43,8 @@ def test_load_table_model_raises_when_not_available(model_path):
 def test_table_model_inherit_init():
     table_model = tables.UnstructuredTableTransformerModel()
     assert hasattr(table_model, "model")
-    assert table_model.model == None
+    assert table_model.model is None
+
 
 @pytest.mark.parametrize(
     "model_path",

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.13-dev0"  # pragma: no cover
+__version__ = "0.7.13"  # pragma: no cover

--- a/unstructured_inference/models/tables.py
+++ b/unstructured_inference/models/tables.py
@@ -31,9 +31,6 @@ from . import table_postprocess as postprocess
 class UnstructuredTableTransformerModel(UnstructuredModel):
     """Unstructured model wrapper for table-transformer."""
 
-    def __init__(self):
-        pass
-
     def predict(self, x: Image, ocr_tokens: Optional[List[Dict]] = None):
         """Predict table structure deferring to run_prediction with ocr tokens
 


### PR DESCRIPTION
### Summary

Fix: https://github.com/Unstructured-IO/unstructured/issues/2028

* don't override init function for UnstructuredTableTransformerModel so that it will has field "model"

### Test
on main branch of inference repo, open a python terminal, run the code snippet and will see error
```
>>> from unstructured_inference.models.tables import UnstructuredTableTransformerModel
>>> table_agent = UnstructuredTableTransformerModel()
>>> table_agent.model
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'UnstructuredTableTransformerModel' object has no attribute 'model'
```
now checkout to this branch and open a python terminal again, the error should be gone