### PR TITLE
Chore: nit of table init logger to show up the log info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 0.7.13-dev0
+## 0.7.13-dev1
 
+* fix: update logger in table initalization where the logger info was not showing
 * chore: supress UserWarning about specified model providers
 
 ## 0.7.12

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.13-dev0"  # pragma: no cover
+__version__ = "0.7.13-dev1"  # pragma: no cover

--- a/unstructured_inference/models/tables.py
+++ b/unstructured_inference/models/tables.py
@@ -1,6 +1,5 @@
 # https://github.com/microsoft/table-transformer/blob/main/src/inference.py
 # https://github.com/NielsRogge/Transformers-Tutorials/blob/master/Table%20Transformer/Using_Table_Transformer_for_table_detection_and_table_structure_recognition.ipynb
-import logging
 import os
 import xml.etree.ElementTree as ET
 from collections import defaultdict
@@ -63,13 +62,13 @@ class UnstructuredTableTransformerModel(UnstructuredModel):
         self.feature_extractor = DetrImageProcessor()
 
         try:
-            logging.info("Loading the table structure model ...")
+            logger.info("Loading the table structure model ...")
             self.model = TableTransformerForObjectDetection.from_pretrained(model)
             self.model.eval()
 
         except EnvironmentError:
-            logging.critical("Failed to initialize the model.")
-            logging.critical("Ensure that the model is correct")
+            logger.critical("Failed to initialize the model.")
+            logger.critical("Ensure that the model is correct")
             raise ImportError(
                 "Review the parameters to initialize a UnstructuredTableTransformerModel obj",
             )


### PR DESCRIPTION
`"Loading the table structure model ..."` wasn't showing up in log since it was using `logging.info` not `logger.info`