### PR TITLE
fix: prevent image zoom too large for tesseract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.7.19-dev0
+## 0.7.19
 
 * fix: fix a bug where an image may be scaled beyond the limit for tesseract to process
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.19-dev0
+
+* fix: fix a bug where an image may be scaled beyond the limit for tesseract to process
+
 ## 0.7.18
 
 * refactor: remove all image extraction related code

--- a/test_unstructured_inference/models/test_tables.py
+++ b/test_unstructured_inference/models/test_tables.py
@@ -714,3 +714,11 @@ def test_padded_results_has_right_dimensions(table_transformer, example_image):
         x1, y1, x2, y2 = obj["bbox"]
         assert max(x1, x2) < width + pad
         assert max(y1, y2) < height + pad
+
+
+def test_auto_zoom_not_exceed_tesseract_limit(monkeypatch, example_image):
+    monkeypatch.setenv("TESSERACT_MIN_TEXT_HEIGHT", "10000")
+    monkeypatch.setenv("TESSERACT_OPTIMUM_TEXT_HEIGHT", "100000")
+    model = tables.UnstructuredTableTransformerModel()
+    model.initialize("microsoft/table-transformer-structure-recognition")
+    assert model.get_tokens(example_image)

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.19-dev0"  # pragma: no cover
+__version__ = "0.7.19"  # pragma: no cover

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.18"  # pragma: no cover
+__version__ = "0.7.19-dev0"  # pragma: no cover

--- a/unstructured_inference/constants.py
+++ b/unstructured_inference/constants.py
@@ -38,5 +38,8 @@ class ElementType:
 
 FULL_PAGE_REGION_THRESHOLD = 0.99
 
+# 2 ** 31 - 1
+TESSERACT_MAX_SIZE = 2147483647
+
 # this field is defined by pytesseract/unstructured.pytesseract
 TESSERACT_TEXT_HEIGHT = "height"


### PR DESCRIPTION
This PR addresses [CORE-2965](https://unstructured-ai.atlassian.net/browse/CORE-2965) by limiting zoom factor so that the scaled image can still be processed by tesseract.

## test

A unit test is added in this PR to test a unlikely case where we'd scale an image a few thousand times and massively exceed the limit without the fix.

Unstructured reviewers can also use the document in the ticket to test.

[CORE-2965]: https://unstructured-ai.atlassian.net/browse/CORE-2965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ