### PR TITLE
fix: intersections involving rectangles with None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.22
+
+* fix: add logic to handle computation of intersections betwen 2 `Rectangle`s when a `Rectangle` has `None` value in its coordinates
+
 ## 0.7.21
 
 * fix: fix a bug where chipper, or any element extraction model based `PageLayout` object, lack `image_metadata` and other attributes that are required for downstream processing; this fix also reduces the memory overhead of using chipper model

--- a/test_unstructured_inference/test_elements.py
+++ b/test_unstructured_inference/test_elements.py
@@ -6,12 +6,12 @@ import pytest
 
 from unstructured_inference.constants import ElementType
 from unstructured_inference.inference import elements
-from unstructured_inference.inference.elements import TextRegion
+from unstructured_inference.inference.elements import Rectangle, TextRegion
 from unstructured_inference.inference.layoutelement import (
+    LayoutElement,
+    merge_inferred_layout_with_extracted_layout,
     partition_groups_from_regions,
     separate,
-    merge_inferred_layout_with_extracted_layout,
-    LayoutElement,
 )
 
 skip_outside_ci = os.getenv("CI", "").lower() in {"", "false", "f", "0"}
@@ -29,6 +29,18 @@ def rand_rect(size=10):
     x1 = randint(0, 30 - size)
     y1 = randint(0, 30 - size)
     return elements.Rectangle(x1, y1, x1 + size, y1 + size)
+
+
+@pytest.mark.parametrize(
+    ("rect1", "rect2", "expected"),
+    [
+        (Rectangle(0, 0, 1, 1), Rectangle(0, 0, None, None), None),
+        (Rectangle(0, 0, None, None), Rectangle(0, 0, 1, 1), None),
+    ],
+)
+def test_unhappy_intersection(rect1, rect2, expected):
+    assert rect1.intersection(rect2) == expected
+    assert not rect1.intersects(rect2)
 
 
 @pytest.mark.parametrize("second_size", [10, 20])
@@ -198,7 +210,10 @@ def test_intersection_over_min(
 
 
 def test_grow_region_to_match_region():
-    from unstructured_inference.inference.elements import Rectangle, grow_region_to_match_region
+    from unstructured_inference.inference.elements import (
+        Rectangle,
+        grow_region_to_match_region,
+    )
 
     a = Rectangle(1, 1, 2, 2)
     b = Rectangle(1, 1, 5, 5)

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.21"  # pragma: no cover
+__version__ = "0.7.22"  # pragma: no cover

--- a/unstructured_inference/inference/elements.py
+++ b/unstructured_inference/inference/elements.py
@@ -67,6 +67,8 @@ class Rectangle:
 
     def intersects(self, other: Rectangle) -> bool:
         """Checks whether this rectangle intersects another rectangle."""
+        if self._has_none() or other._has_none():
+            return False
         return intersections(self, other)[0, 1]
 
     def is_in(self, other: Rectangle, error_margin: Optional[Union[int, float]] = None) -> bool:
@@ -81,6 +83,10 @@ class Rectangle:
             ],
         )
 
+    def _has_none(self) -> bool:
+        """return false when one of the coord is nan"""
+        return any((self.x1 is None, self.x2 is None, self.y1 is None, self.y2 is None))
+
     @property
     def coordinates(self):
         """Gets coordinates of the rectangle"""
@@ -89,6 +95,8 @@ class Rectangle:
     def intersection(self, other: Rectangle) -> Optional[Rectangle]:
         """Gives the rectangle that is the intersection of two rectangles, or None if the
         rectangles are disjoint."""
+        if self._has_none() or other._has_none():
+            return None
         x1 = max(self.x1, other.x1)
         x2 = min(self.x2, other.x2)
         y1 = max(self.y1, other.y1)


### PR DESCRIPTION
This PR fixes #310 that is popping up again 
- now returns None instead of raising an exception
- a followup is needed to understand why some `Rectangles` has `None` value as coordinates.
