### PR TITLE
fix: handling for empty table recognition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 env:
-  PYTHON_VERSION: 3.8
+  PYTHON_VERSION: 3.9
 
 jobs:
   setup:
@@ -107,7 +107,7 @@ jobs:
   test_ingest:
     strategy:
       matrix:
-        python-version: ["3.8","3.9","3.10"]
+        python-version: ["3.9","3.10"]
     runs-on: ubuntu-latest
     env:
       NLTK_DATA: ${{ github.workspace }}/nltk_data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.7.23
+
+* fix: added handling in `UnstructuredTableTransformerModel` for if `recognize` returns an empty
+  list in `run_prediction`.
+
 ## 0.7.22
 
 * fix: add logic to handle computation of intersections betwen 2 `Rectangle`s when a `Rectangle` has `None` value in its coordinates

--- a/test_unstructured_inference/models/test_tables.py
+++ b/test_unstructured_inference/models/test_tables.py
@@ -932,6 +932,21 @@ def test_table_prediction_output_format(
         assert expectation in result
 
 
+def test_table_prediction_runs_with_empty_recognize(
+    table_transformer,
+    example_image,
+    mocker,
+    mocked_ocr_tokens,
+):
+    mocker.patch.object(tables, "recognize", return_value=[])
+    mocker.patch.object(
+        tables.UnstructuredTableTransformerModel,
+        "get_structure",
+        return_value=None,
+    )
+    assert table_transformer.run_prediction(example_image, ocr_tokens=mocked_ocr_tokens) == ""
+
+
 def test_table_prediction_with_ocr_tokens(table_transformer, example_image, mocked_ocr_tokens):
     prediction = table_transformer.predict(example_image, ocr_tokens=mocked_ocr_tokens)
     assert '<table><thead><th rowspan="2">' in prediction

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.22"  # pragma: no cover
+__version__ = "0.7.23"  # pragma: no cover

--- a/unstructured_inference/models/tables.py
+++ b/unstructured_inference/models/tables.py
@@ -96,7 +96,14 @@ class UnstructuredTableTransformerModel(UnstructuredModel):
         outputs_structure = self.get_structure(x, pad_for_structure_detection)
         if ocr_tokens is None:
             raise ValueError("Cannot predict table structure with no OCR tokens")
-        prediction = recognize(outputs_structure, x, tokens=ocr_tokens)[0]
+
+        recognized_table = recognize(outputs_structure, x, tokens=ocr_tokens)
+        if len(recognized_table) > 0:
+            prediction = recognized_table[0]
+        # NOTE(robinson) - This means that the table was not recognized
+        else:
+            return ""
+
         if result_format == "html":
             # Convert cells to HTML
             prediction = cells_to_html(prediction) or ""


### PR DESCRIPTION
### Summary

Closes #306. Addresses the condition where `recognize` returns an empty list in the `run_prediction` method on `UnstructuredTableTransformerModel`.

### Testing

`pytest test_unstructured_inference/models/test_tables.py`