### PR TITLE
Fix `html_as_text` appearing in every element metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.24
+
+* fix: assign value to `text_as_html` element attribute only if `text` attribute contains HTML tags.
+
 ## 0.7.23
 
 * fix: added handling in `UnstructuredTableTransformerModel` for if `recognize` returns an empty

--- a/unstructured_inference/inference/layoutelement.py
+++ b/unstructured_inference/inference/layoutelement.py
@@ -31,6 +31,7 @@ class LayoutElement(TextRegion):
     prob: Optional[float] = None
     image_path: Optional[str] = None
     parent: Optional[LayoutElement] = None
+    text_as_html: Optional[str] = None
 
     def extract_text(
         self,

--- a/unstructured_inference/models/chipper.py
+++ b/unstructured_inference/models/chipper.py
@@ -171,16 +171,18 @@ class UnstructuredChipperModel(UnstructuredElementExtractionModel):
         return elements
 
     @staticmethod
-    def format_table_elements(elements):
-        """makes chipper table element return the same as other layout models
+    def format_table_elements(elements: List[LayoutElement]) -> List[LayoutElement]:
+        """Makes chipper table element return the same as other layout models.
 
-        - copies the html representation to attribute text_as_html
-        - strip html tags from the attribute text
+        1. If `text` attribute is an html (has html tags in it), copies the `text`
+        attribute to `text_as_html` attribute.
+        2. Strips html tags from the `text` attribute.
         """
         for element in elements:
-            element.text_as_html = element.text
-            element.text = strip_tags(element.text)
-
+            text = strip_tags(element.text) if element.text is not None else element.text
+            if text != element.text:
+                element.text_as_html = element.text
+            element.text = text
         return elements
 
     def predict_tokens(


### PR DESCRIPTION
This PR fixes the issue described here: Unstructured-IO/unstructured#2463

Now `text_as_html` will only be available for elements that are HTML strings (contain HTML tags)

E.g. output for **non** html element

```json
{
    "element_id": "4a44dc15364204a80fe80e9039455cc1",
    "metadata": {
      "coordinates": {
        "layout_height": 3301,
        "layout_width": 2550,
        "points": [
          [170, 13],
          [170, 140],
          [427, 140],
          [427, 13]
        ],
        "system": "PixelSpace"
      },
      "file_directory": "/home/ubuntu/Documents",
      "filename": "purchasing-payment-policy-10.pdf",
      "filetype": "application/pdf",
      "languages": ["eng"],
      "last_modified": "2024-02-02T11:49:38",
      "page_number": 1,
      "parent_id": "e3b0c44298fc1c149afbf4c8996fb924"
    },
    "text": "10",
    "type": "UncategorizedText"
  }
```

E.g. output for html element
```json
{
    "element_id": "398766f59dd6b37bd38b6d612159cd3e",
    "metadata": {
      "coordinates": {
        "layout_height": 3301,
        "layout_width": 2550,
        "points": [
          [433, 2180],
          [433, 2181],
          [2290, 2181],
          [2290, 2180]
        ],
        "system": "PixelSpace"
      },
      "file_directory": "/home/ubuntu/Documents",
      "filename": "purchasing-payment-policy-10.pdf",
      "filetype": "application/pdf",
      "languages": ["eng"],
      "last_modified": "2024-02-02T11:49:38",
      "page_number": 1,
      "text_as_html": "<table><tbody><tr><td></td><td> Subject Matter Expert / Department</td><td> Contract Review Responsibility</td><td></td></tr><tbody></table>"
    },
    "text": "Subject Matter Expert / Department Contract Review Responsibility",
    "type": "Table"
  }
```