### PR TITLE
chore: remove install-detectron2 make target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.25-dev0
+
+* chore: removes `install-detectron2` from the `Makefile`
+
 ## 0.7.24
 
 * fix: assign value to `text_as_html` element attribute only if `text` attribute contains HTML tags.

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ install-base: install-base-pip-packages
 
 ## install:                 installs all test, dev, and experimental requirements
 .PHONY: install
-install: install-base-pip-packages install-dev install-detectron2
+install: install-base-pip-packages install-dev
 
 .PHONY: install-ci
 install-ci: install-base-pip-packages install-test
@@ -27,10 +27,6 @@ install-ci: install-base-pip-packages install-test
 .PHONY: install-base-pip-packages
 install-base-pip-packages:
 	python3 -m pip install pip==${PIP_VERSION}
-
-.PHONY: install-detectron2
-install-detectron2:
-	pip install "detectron2@git+https://github.com/facebookresearch/detectron2.git@57bdb21249d5418c130d54e2ebdc94dda7a4c01a"
 
 .PHONY: install-test
 install-test: install-base
@@ -44,10 +40,6 @@ install-dev: install-test
 .PHONY: pip-compile
 pip-compile:
 	pip-compile --upgrade requirements/base.in
-	# NOTE(robinson) - We want the dependencies for detectron2 in the requirements.txt, but not
-	# the detectron2 repo itself. If detectron2 is in the requirements.txt file, an order of
-	# operations issue related to the torch library causes the install to fail
-	sed 's/^detectron2 @/# detectron2 @/g' requirements/base.txt
 	pip-compile --upgrade requirements/test.in
 	pip-compile --upgrade requirements/dev.in
 

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.24"  # pragma: no cover
+__version__ = "0.7.25-dev0"  # pragma: no cover


### PR DESCRIPTION
### Summary

Removes the `install-detectron2` target from the `Makefile` since we use the ONNX version of the Detectron2 modle now.