### PR TITLE
Enhancement: Allow table_agent to load from external parameter `UNSTRUCTURED_TABLE_AGENT_MODEL_PATH`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.7.25-dev0
 
 * chore: removes `install-detectron2` from the `Makefile`
+# enhancement: allow table_agent to load from external parameter `UNSTRUCTURED_TABLE_AGENT_MODEL_PATH`
 
 ## 0.7.24
 

--- a/unstructured_inference/models/tables.py
+++ b/unstructured_inference/models/tables.py
@@ -1,5 +1,6 @@
 # https://github.com/microsoft/table-transformer/blob/main/src/inference.py
 # https://github.com/NielsRogge/Transformers-Tutorials/blob/master/Table%20Transformer/Using_Table_Transformer_for_table_detection_and_table_structure_recognition.ipynb
+import os
 import xml.etree.ElementTree as ET
 from collections import defaultdict
 from pathlib import Path
@@ -121,7 +122,11 @@ def load_agent():
 
     if not hasattr(tables_agent, "model"):
         logger.info("Loading the Table agent ...")
-        tables_agent.initialize("microsoft/table-transformer-structure-recognition")
+        table_agent_model_path = os.environ.get("UNSTRUCTURED_TABLE_AGENT_MODEL_PATH")
+        if table_agent_model_path is not None:
+            tables_agent.initialize(table_agent_model_path)
+        else:
+            tables_agent.initialize("microsoft/table-transformer-structure-recognition")
 
     return
 


### PR DESCRIPTION
Allow table_agent to read the model path set via os environment `UNSTRUCTURED_TABLE_AGENT_MODEL_PATH`. This would allow unstructured-inference to run local inference, if needed.