### PR TITLE
Fix: embedded text not getting merged with inferred elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 0.7.25-dev2
+## 0.7.25-dev3
 
+* fix: replace `Rectangle.is_in()` with `Rectangle.is_almost_subregion_of()` when filling in an inferred element with embedded text
 * bug: check for None in Chipper bounding box reduction
 * chore: removes `install-detectron2` from the `Makefile`
 * fix: convert label_map keys read from os.environment `UNSTRUCTURED_DEFAULT_MODEL_INITIALIZE_PARAMS_JSON_PATH` to int type

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.7.25-dev3
+## 0.7.25
 
 * fix: replace `Rectangle.is_in()` with `Rectangle.is_almost_subregion_of()` when filling in an inferred element with embedded text
 * bug: check for None in Chipper bounding box reduction

--- a/test_unstructured_inference/test_elements.py
+++ b/test_unstructured_inference/test_elements.py
@@ -272,3 +272,16 @@ def test_merge_inferred_layout_with_extracted_layout():
     assert merged_layout[0].text == "Example Section Header"
     assert merged_layout[1].type == ElementType.TEXT
     assert merged_layout[1].text == "Example Title"
+
+
+def test_aggregate_by_block():
+    expected = "Inside region1 Inside region2"
+    embedded_regions = [
+        TextRegion.from_coords(0, 0, 20, 20, "Inside region1"),
+        TextRegion.from_coords(50, 50, 150, 150, "Inside region2"),
+        TextRegion.from_coords(250, 250, 350, 350, "Outside region"),
+    ]
+    target_region = TextRegion.from_coords(0, 0, 300, 300)
+
+    text = elements.aggregate_by_block(target_region, embedded_regions)
+    assert text == expected

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.25-dev2"  # pragma: no cover
+__version__ = "0.7.25-dev3"  # pragma: no cover

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.25-dev3"  # pragma: no cover
+__version__ = "0.7.25"  # pragma: no cover

--- a/unstructured_inference/config.py
+++ b/unstructured_inference/config.py
@@ -92,6 +92,16 @@ class InferenceConfig:
         return self._get_float("LAYOUT_SUBREGION_THRESHOLD", 0.75)
 
     @property
+    def EMBEDDED_TEXT_AGGREGATION_SUBREGION_THRESHOLD(self) -> float:
+        """threshold to determine if an embedded region is a sub-region of a given block
+        when aggregating the text from embedded elements that lie within the given block
+
+        When the intersection region area divided by self area is larger than this threshold self is
+        considered a subregion of the other
+        """
+        return self._get_float("EMBEDDED_TEXT_AGGREGATION_SUBREGION_THRESHOLD", 0.95)
+
+    @property
     def ELEMENTS_H_PADDING_COEF(self) -> float:
         """When extending the boundaries of a PDF object for the purpose of determining which other
         elements should be considered in the same text region, we use a relative distance based on

--- a/unstructured_inference/config.py
+++ b/unstructured_inference/config.py
@@ -99,7 +99,7 @@ class InferenceConfig:
         When the intersection region area divided by self area is larger than this threshold self is
         considered a subregion of the other
         """
-        return self._get_float("EMBEDDED_TEXT_AGGREGATION_SUBREGION_THRESHOLD", 0.95)
+        return self._get_float("EMBEDDED_TEXT_AGGREGATION_SUBREGION_THRESHOLD", 0.99)
 
     @property
     def ELEMENTS_H_PADDING_COEF(self) -> float:

--- a/unstructured_inference/inference/elements.py
+++ b/unstructured_inference/inference/elements.py
@@ -8,6 +8,7 @@ from typing import Collection, Optional, Union
 
 import numpy as np
 
+from unstructured_inference.config import inference_config
 from unstructured_inference.constants import Source
 from unstructured_inference.math import safe_division
 
@@ -247,7 +248,11 @@ def aggregate_by_block(
     """Extracts the text aggregated from the elements of the given layout that lie within the given
     block."""
     filtered_blocks = [
-        obj for obj in pdf_objects if obj.bbox.is_in(text_region.bbox, error_margin=5)
+        obj
+        for obj in pdf_objects
+        if obj.bbox.is_almost_subregion_of(
+            text_region.bbox, inference_config.LAYOUT_SUBREGION_THRESHOLD
+        )
     ]
     text = " ".join([x.text for x in filtered_blocks if x.text])
     return text

--- a/unstructured_inference/inference/elements.py
+++ b/unstructured_inference/inference/elements.py
@@ -242,7 +242,7 @@ class ImageTextRegion(TextRegion):
 
 
 def aggregate_by_block(
-    target_region: TextRegion,
+    text_region: TextRegion,
     pdf_objects: Collection[TextRegion],
 ) -> str:
     """Extracts the text aggregated from the elements of the given layout that lie within the given
@@ -252,7 +252,7 @@ def aggregate_by_block(
     filtered_blocks = [
         obj
         for obj in pdf_objects
-        if obj.bbox.is_almost_subregion_of(target_region.bbox, subregion_threshold)
+        if obj.bbox.is_almost_subregion_of(text_region.bbox, subregion_threshold)
     ]
     text = " ".join([x.text for x in filtered_blocks if x.text])
     return text

--- a/unstructured_inference/inference/elements.py
+++ b/unstructured_inference/inference/elements.py
@@ -129,7 +129,11 @@ class Rectangle:
         min_area = min(self.area, other.area)
         return safe_division(intersection_area, min_area)
 
-    def is_almost_subregion_of(self, other: Rectangle, subregion_threshold: float = 0.75) -> bool:
+    def is_almost_subregion_of(
+        self,
+        other: Rectangle,
+        subregion_threshold: float = inference_config.LAYOUT_SUBREGION_THRESHOLD,
+    ) -> bool:
         """Returns whether this region is almost a subregion of other. This is determined by
         comparing the intersection area over self area to some threshold, and checking whether self
         is the smaller rectangle."""
@@ -248,11 +252,7 @@ def aggregate_by_block(
     """Extracts the text aggregated from the elements of the given layout that lie within the given
     block."""
     filtered_blocks = [
-        obj
-        for obj in pdf_objects
-        if obj.bbox.is_almost_subregion_of(
-            text_region.bbox, inference_config.LAYOUT_SUBREGION_THRESHOLD
-        )
+        obj for obj in pdf_objects if obj.bbox.is_almost_subregion_of(text_region.bbox)
     ]
     text = " ".join([x.text for x in filtered_blocks if x.text])
     return text
@@ -288,7 +288,7 @@ def remove_control_characters(text: str) -> str:
 def region_bounding_boxes_are_almost_the_same(
     region1: Rectangle,
     region2: Rectangle,
-    same_region_threshold: float = 0.75,
+    same_region_threshold: float = inference_config.LAYOUT_SAME_REGION_THRESHOLD,
 ) -> bool:
     """Returns whether bounding boxes are almost the same. This is determined by checking if the
     intersection over union is above some threshold."""

--- a/unstructured_inference/inference/elements.py
+++ b/unstructured_inference/inference/elements.py
@@ -129,11 +129,7 @@ class Rectangle:
         min_area = min(self.area, other.area)
         return safe_division(intersection_area, min_area)
 
-    def is_almost_subregion_of(
-        self,
-        other: Rectangle,
-        subregion_threshold: float = inference_config.LAYOUT_SUBREGION_THRESHOLD,
-    ) -> bool:
+    def is_almost_subregion_of(self, other: Rectangle, subregion_threshold: float = 0.75) -> bool:
         """Returns whether this region is almost a subregion of other. This is determined by
         comparing the intersection area over self area to some threshold, and checking whether self
         is the smaller rectangle."""
@@ -246,13 +242,17 @@ class ImageTextRegion(TextRegion):
 
 
 def aggregate_by_block(
-    text_region: TextRegion,
+    target_region: TextRegion,
     pdf_objects: Collection[TextRegion],
 ) -> str:
     """Extracts the text aggregated from the elements of the given layout that lie within the given
     block."""
+
+    subregion_threshold = inference_config.EMBEDDED_TEXT_AGGREGATION_SUBREGION_THRESHOLD
     filtered_blocks = [
-        obj for obj in pdf_objects if obj.bbox.is_almost_subregion_of(text_region.bbox)
+        obj
+        for obj in pdf_objects
+        if obj.bbox.is_almost_subregion_of(target_region.bbox, subregion_threshold)
     ]
     text = " ".join([x.text for x in filtered_blocks if x.text])
     return text
@@ -288,7 +288,7 @@ def remove_control_characters(text: str) -> str:
 def region_bounding_boxes_are_almost_the_same(
     region1: Rectangle,
     region2: Rectangle,
-    same_region_threshold: float = inference_config.LAYOUT_SAME_REGION_THRESHOLD,
+    same_region_threshold: float = 0.75,
 ) -> bool:
     """Returns whether bounding boxes are almost the same. This is determined by checking if the
     intersection over union is above some threshold."""


### PR DESCRIPTION
This PR is the first part of fixing "embedded text not getting merged with inferred elements" and works together with the unstructured PR - https://github.com/Unstructured-IO/unstructured/pull/2679.

### Summary
- replace `Rectangle.is_in()` with `Rectangle.is_almost_subregion_of()` when filling in an inferred element with embedded text
- add env_config `EMBEDDED_TEXT_AGGREGATION_SUBREGION_THRESHOLD`

### Note
The ingest test won't pass until we merge the unstructured PR - https://github.com/Unstructured-IO/unstructured/pull/2679.