### PR TITLE
Refactor/get model allow registering of new models with function calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
-## 0.7.26-dev0
+## 0.7.26
+
 * feat: add a set of new `ElementType`s to extend future element types recognition
+* feat: allow registering of new models for inference using `unstructured_inference.models.base.register_new_model` function
 
 ## 0.7.25
 

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.26-dev0"  # pragma: no cover
+__version__ = "0.7.26"  # pragma: no cover

--- a/unstructured_inference/config.py
+++ b/unstructured_inference/config.py
@@ -5,6 +5,7 @@ this module. Constants are values that are usually names for common options (e.g
 settings that should not be altered without making a code change (e.g., definition of 1Gb of memory
 in bytes). Constants should go into `./constants.py`
 """
+
 import os
 from dataclasses import dataclass
 

--- a/unstructured_inference/inference/layoutelement.py
+++ b/unstructured_inference/inference/layoutelement.py
@@ -165,9 +165,11 @@ def merge_inferred_layout_with_extracted_layout(
     categorized_extracted_elements_to_add = [
         LayoutElement(
             text=el.text,
-            type=ElementType.IMAGE
-            if isinstance(el, ImageTextRegion)
-            else ElementType.UNCATEGORIZED_TEXT,
+            type=(
+                ElementType.IMAGE
+                if isinstance(el, ImageTextRegion)
+                else ElementType.UNCATEGORIZED_TEXT
+            ),
             source=el.source,
             bbox=el.bbox,
         )

--- a/unstructured_inference/models/base.py
+++ b/unstructured_inference/models/base.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import json
 import os
-from typing import Dict, Optional, Tuple, Type, Union
+from typing import Dict, Optional, Tuple, Type
 
 from unstructured_inference.models.chipper import MODEL_TYPES as CHIPPER_MODEL_TYPES
 from unstructured_inference.models.chipper import UnstructuredChipperModel
@@ -25,7 +27,7 @@ models: Dict[str, UnstructuredModel] = {}
 def get_default_model_mappings() -> (
     Tuple[
         Dict[str, Type[UnstructuredModel]],
-        Dict[str, Union[dict, LazyDict]],
+        Dict[str, dict | LazyDict],
     ]
 ):
     """default model mappings for models that are in `unstructured_inference` repo"""

--- a/unstructured_inference/models/base.py
+++ b/unstructured_inference/models/base.py
@@ -1,6 +1,6 @@
 import json
 import os
-from typing import Dict, Optional, Tuple, Type
+from typing import Dict, Optional, Tuple, Type, Union
 
 from unstructured_inference.models.chipper import MODEL_TYPES as CHIPPER_MODEL_TYPES
 from unstructured_inference.models.chipper import UnstructuredChipperModel
@@ -25,7 +25,7 @@ models: Dict[str, UnstructuredModel] = {}
 def get_default_model_mappings() -> (
     Tuple[
         Dict[str, Type[UnstructuredModel]],
-        Dict[str, dict | LazyDict],
+        Dict[str, Union[dict, LazyDict]],
     ]
 ):
     """default model mappings for models that are in `unstructured_inference` repo"""

--- a/unstructured_inference/models/base.py
+++ b/unstructured_inference/models/base.py
@@ -15,13 +15,17 @@ from unstructured_inference.models.detectron2onnx import UnstructuredDetectronON
 from unstructured_inference.models.unstructuredmodel import UnstructuredModel
 from unstructured_inference.models.yolox import MODEL_TYPES as YOLOX_MODEL_TYPES
 from unstructured_inference.models.yolox import UnstructuredYoloXModel
+from unstructured_inference.utils import LazyDict
 
 DEFAULT_MODEL = "yolox"
 
 models: Dict[str, UnstructuredModel] = {}
 
 
-def get_default_model_mappings() -> Tuple[Dict[str, Type[UnstructuredModel]], Dict[str, dict]]:
+def get_default_model_mappings() -> Tuple[
+    Dict[str, Type[UnstructuredModel]],
+    Dict[str, dict | LazyDict],
+]:
     """default model mappings for models that are in `unstructured_inference` repo"""
     return {
         **{name: UnstructuredDetectronModel for name in DETECTRON2_MODEL_TYPES},

--- a/unstructured_inference/models/base.py
+++ b/unstructured_inference/models/base.py
@@ -22,10 +22,12 @@ DEFAULT_MODEL = "yolox"
 models: Dict[str, UnstructuredModel] = {}
 
 
-def get_default_model_mappings() -> Tuple[
-    Dict[str, Type[UnstructuredModel]],
-    Dict[str, dict | LazyDict],
-]:
+def get_default_model_mappings() -> (
+    Tuple[
+        Dict[str, Type[UnstructuredModel]],
+        Dict[str, dict | LazyDict],
+    ]
+):
     """default model mappings for models that are in `unstructured_inference` repo"""
     return {
         **{name: UnstructuredDetectronModel for name in DETECTRON2_MODEL_TYPES},


### PR DESCRIPTION
This PR allows us to register new models and use them in the system:
- refactor of `get_model` so it relies on information stored in `model_class_map` and `model_config_map` to initialize a new model with a given model name (which is the key to both mappings)
- a new function `unstructured_inference.models.base.register_new_model` now allows adding new model definition to the class mapping and config mapping
- after calling register new model one can now call `get_model` with the new model name and get the new model

## testing

New unit tests should pass