### PR TITLE
refactor: remove all `cid` related code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.31-dev0
+
+* refactor: remove all `cid` related code that was originally added to filter out invalid `pdfminer` text 
+
 ## 0.7.30
 
 * fix: table transformer doesn't return multiple cells with same coordinates 

--- a/test_unstructured_inference/inference/test_layout.py
+++ b/test_unstructured_inference/inference/test_layout.py
@@ -227,33 +227,6 @@ class MockPageLayout(layout.PageLayout):
         self.detection_model = detection_model
 
 
-@pytest.mark.parametrize(
-    ("text", "expected"),
-    [
-        ("base", 0.0),
-        ("", 0.0),
-        ("(cid:2)", 1.0),
-        ("(cid:1)a", 0.5),
-        ("c(cid:1)ab", 0.25),
-    ],
-)
-def test_cid_ratio(text, expected):
-    assert elements.cid_ratio(text) == expected
-
-
-@pytest.mark.parametrize(
-    ("text", "expected"),
-    [
-        ("base", False),
-        ("(cid:2)", True),
-        ("(cid:1234567890)", True),
-        ("jkl;(cid:12)asdf", True),
-    ],
-)
-def test_is_cid_present(text, expected):
-    assert elements.is_cid_present(text) == expected
-
-
 class MockLayout:
     def __init__(self, *elements):
         self.elements = elements
@@ -394,13 +367,6 @@ def test_remove_control_characters(text, expected):
 
 no_text_region = EmbeddedTextRegion.from_coords(0, 0, 100, 100)
 text_region = EmbeddedTextRegion.from_coords(0, 0, 100, 100, text="test")
-cid_text_region = EmbeddedTextRegion.from_coords(
-    0,
-    0,
-    100,
-    100,
-    text="(cid:1)(cid:2)(cid:3)(cid:4)(cid:5)",
-)
 overlapping_rect = ImageTextRegion.from_coords(50, 50, 150, 150)
 nonoverlapping_rect = ImageTextRegion.from_coords(150, 150, 200, 200)
 populated_text_region = EmbeddedTextRegion.from_coords(50, 50, 60, 60, text="test")

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.30"  # pragma: no cover
+__version__ = "0.7.31-dev0"  # pragma: no cover

--- a/unstructured_inference/inference/elements.py
+++ b/unstructured_inference/inference/elements.py
@@ -258,23 +258,6 @@ def aggregate_by_block(
     return text
 
 
-def cid_ratio(text: str) -> float:
-    """Gets ratio of unknown 'cid' characters extracted from text to all characters."""
-    if not is_cid_present(text):
-        return 0.0
-    cid_pattern = r"\(cid\:(\d+)\)"
-    unmatched, n_cid = re.subn(cid_pattern, "", text)
-    total = n_cid + len(unmatched)
-    return n_cid / total
-
-
-def is_cid_present(text: str) -> bool:
-    """Checks if a cid code is present in a text selection."""
-    if len(text) < len("(cid:x)"):
-        return False
-    return text.find("(cid:") != -1
-
-
 def remove_control_characters(text: str) -> str:
     """Removes control characters from text."""
 

--- a/unstructured_inference/inference/elements.py
+++ b/unstructured_inference/inference/elements.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import re
 import unicodedata
 from copy import deepcopy
 from dataclasses import dataclass

--- a/unstructured_inference/models/tables.py
+++ b/unstructured_inference/models/tables.py
@@ -3,7 +3,7 @@
 import xml.etree.ElementTree as ET
 from collections import defaultdict
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Union
 
 import cv2
 import numpy as np
@@ -188,7 +188,7 @@ def recognize(outputs: dict, img: PILImage.Image, tokens: list):
 
 def outputs_to_objects(
     outputs: TableTransformerObjectDetectionOutput,
-    img_size: tuple[int, int],
+    img_size: Tuple[int, int],
     class_idx2name: Mapping[int, str],
 ):
     """Output table element types."""


### PR DESCRIPTION
This PR removes all `cid` related code. This PR is the first part of moving `cid` related code from `unstructured-inference` to `unstructured` and works together with https://github.com/Unstructured-IO/unstructured/pull/2970.