### PR TITLE
feat: onnx expose session options

### DIFF
--- a/test_unstructured_inference/models/test_detectron2onnx.py
+++ b/test_unstructured_inference/models/test_detectron2onnx.py
@@ -37,11 +37,18 @@ def test_load_default_model(monkeypatch):
 
 @pytest.mark.parametrize(("model_path", "label_map"), [("asdf", "diufs"), ("dfaw", "hfhfhfh")])
 def test_load_model(model_path, label_map):
-    with patch.object(detectron2.onnxruntime, "InferenceSession", return_value=True):
+    session_options_dict = {"intra_op_num_threads": 1, "inter_op_num_threads": 1}
+    with patch.object(detectron2.onnxruntime, "InferenceSession") as mock_session:
         model = detectron2.UnstructuredDetectronONNXModel()
-        model.initialize(model_path=model_path, label_map=label_map)
-        args, _ = detectron2.onnxruntime.InferenceSession.call_args
-        assert args == (model_path,)
+        model.initialize(
+            model_path=model_path,
+            label_map=label_map,
+            session_options_dict=session_options_dict
+        )
+        args, kwargs = mock_session.call_args
+        assert args[0] == model_path
+        assert kwargs['sess_options'].intra_op_num_threads == 1
+        assert kwargs['sess_options'].inter_op_num_threads == 1
     assert label_map == model.label_map
 
 

--- a/unstructured_inference/models/detectron2onnx.py
+++ b/unstructured_inference/models/detectron2onnx.py
@@ -99,6 +99,7 @@ class UnstructuredDetectronONNXModel(UnstructuredObjectDetectionModel):
         model_path: str,
         label_map: Dict[int, str],
         confidence_threshold: Optional[float] = None,
+        session_options_dict: Optional[Dict[str, Union[int, bool, str]]] = None,
     ):
         """Loads the detectron2 model using the specified parameters"""
         if not os.path.exists(model_path) and "detectron2_quantized" in model_path:
@@ -115,8 +116,14 @@ class UnstructuredDetectronONNXModel(UnstructuredObjectDetectionModel):
         ]
         providers = [provider for provider in ordered_providers if provider in available_providers]
 
+        session_options = onnxruntime.SessionOptions()
+        if session_options_dict:
+            for option_name, option_value in session_options_dict.items():
+                setattr(session_options, option_name, option_value)
+
         self.model = onnxruntime.InferenceSession(
             model_path,
+            sess_options=session_options,
             providers=providers,
         )
         self.model_path = model_path

--- a/unstructured_inference/models/yolox.py
+++ b/unstructured_inference/models/yolox.py
@@ -3,7 +3,7 @@
 # https://github.com/Megvii-BaseDetection/YOLOX/blob/237e943ac64aa32eb32f875faa93ebb18512d41d/yolox/data/data_augment.py
 # https://github.com/Megvii-BaseDetection/YOLOX/blob/ac379df3c97d1835ebd319afad0c031c36d03f36/yolox/utils/demo_utils.py
 
-from typing import List, cast
+from typing import Dict, List, Optional, Union, cast
 
 import cv2
 import numpy as np
@@ -68,7 +68,12 @@ class UnstructuredYoloXModel(UnstructuredObjectDetectionModel):
         super().predict(x)
         return self.image_processing(x)
 
-    def initialize(self, model_path: str, label_map: dict):
+    def initialize(
+            self,
+            model_path: str,
+            label_map: dict,
+            session_options_dict: Optional[Dict[str, Union[int, bool, str]]] = None,
+        ):
         """Start inference session for YoloX model."""
         self.model_path = model_path
 
@@ -80,8 +85,14 @@ class UnstructuredYoloXModel(UnstructuredObjectDetectionModel):
         ]
         providers = [provider for provider in ordered_providers if provider in available_providers]
 
+        session_options = onnxruntime.SessionOptions()
+        if session_options_dict:
+            for option_name, option_value in session_options_dict.items():
+                setattr(session_options, option_name, option_value)
+
         self.model = onnxruntime.InferenceSession(
             model_path,
+            sess_options=session_options,
             providers=providers,
         )
 


### PR DESCRIPTION
Optional passthrough [onnxruntime.SessionOptions](https://onnxruntime.ai/docs/api/python/api_summary.html#sessionoptions) to the underlying ONNX [InferenceSession](https://onnxruntime.ai/docs/api/python/api_summary.html#onnxruntime.InferenceSession) – re: [slack thread](https://unstructuredw-kbe4326.slack.com/archives/C044N0YV08G/p1715219594480689?thread_ts=1715187973.852259&cid=C044N0YV08G)

When inference is running in a virtualized environment, e.g. docker container, the ONNX inference session infers the underlying hardware of the host machine such as number of CPU cores, rather than what the container actually has access to (similar issues can arise in other python multiprocessing tools). This can result in oversaturating the CPU cores and having noisy-neighbor issues across containers sharing the host (e.g. a large EC2 with 96 cores).

These passthrough options can be specified using the existing JSON file pointed to via the env variable `UNSTRUCTURED_DEFAULT_MODEL_INITIALIZE_PARAMS_JSON_PATH` and as an example, here's JSON that would limit the model inference to 4 CPU cores:
```
{
    "model_name": "detectron2_onnx",
    "session_options_dict": {
        "intra_op_num_threads": 4,
        "inter_op_num_threads": 4
    }
}
```

Param reference:
* Intra-Op Parallelism: This setting controls the number of threads used for parallel execution within a single operator. For example, if a matrix multiplication operation can be parallelized, this setting determines how many threads will work on that operation. Default is 0 to let onnxruntime choose.
* Inter-Op Parallelism: This controls the number of threads that can run different operators in parallel. For instance, if the model architecture allows for multiple layers or operations to execute simultaneously (i.e., they are not dependent on the output of each other), this setting manages how many of such operations can run at the same time. Default is 0 to let onnxruntime choose.