### PR TITLE
fix: ValueError when converting cells to html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
+## 0.7.36
+
+fix: add input parameter validation to `fill_cells()` when converting cells to html
+
 ## 0.7.35
+
 Fix syntax for generated HTML tables
 
 ## 0.7.34

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.35"  # pragma: no cover
+__version__ = "0.7.36"  # pragma: no cover

--- a/unstructured_inference/inference/layoutelement.py
+++ b/unstructured_inference/inference/layoutelement.py
@@ -214,7 +214,9 @@ def separate(region_a: Rectangle, region_b: Rectangle):
             reduce(keep=region_b, reduce=region_a)
 
 
-def table_cells_to_dataframe(cells: dict, nrows: int = 1, ncols: int = 1, header=None) -> DataFrame:
+def table_cells_to_dataframe(
+    cells: List[dict], nrows: int = 1, ncols: int = 1, header=None
+) -> DataFrame:
     """convert table-transformer's cells data into a pandas dataframe"""
     arr = np.empty((nrows, ncols), dtype=object)
     for cell in cells:

--- a/unstructured_inference/models/tables.py
+++ b/unstructured_inference/models/tables.py
@@ -664,6 +664,9 @@ def fill_cells(cells: List[dict]) -> List[dict]:
         whether this cell is a column header
 
     """
+    if not cells:
+        return []
+
     table_rows_no = max({row for cell in cells for row in cell["row_nums"]})
     table_cols_no = max({col for cell in cells for col in cell["column_nums"]})
     filled = np.zeros((table_rows_no + 1, table_cols_no + 1), dtype=bool)


### PR DESCRIPTION
This PR will address https://github.com/Unstructured-IO/unstructured-inference/issues/357 and https://github.com/Unstructured-IO/unstructured-inference/issues/358.

### Summary
- add logic to validate the input parameter to the fill_cells() function. Now, the function checks if the input is a list of dictionaries before processing.
- correct type hint for parameter `cells` in `table_cells_to_dataframe()`