### PR TITLE
[Windows] Support Windows friendly tempfile access

### DIFF
--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -327,11 +327,13 @@ def process_data_with_model(
 ) -> DocumentLayout:
     """Processes pdf file in the form of a file handler (supporting a read method) into a
     DocumentLayout by using a model identified by model_name."""
-    with tempfile.NamedTemporaryFile() as tmp_file:
-        tmp_file.write(data.read())
-        tmp_file.flush()  # Make sure the file is written out
+    with tempfile.TemporaryDirectory() as tmp_dir_path:
+        tmp_path = os.path.join(tmp_dir_path, f"tmpfile")
+        with open(tmp_path, "wb") as tmp:
+            tmp.write(data.read())
+            tmp.flush()
         layout = process_file_with_model(
-            tmp_file.name,
+            tmp_path,
             model_name,
             **kwargs,
         )


### PR DESCRIPTION
# Description
Windows does not support multiple file access on the same file. Thus after creating the file, Windows will expect the content to be flushed into the file and exit the file object context. Only then the subsequent operation can open the file.

This addressed the issue https://github.com/Unstructured-IO/unstructured-inference/issues/303 