### PR TITLE
vectorize layout elements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,11 +52,10 @@ jobs:
       if: steps.virtualenv-cache.outputs.cache-hit != 'true'
       run: |
         python${{ env.PYTHON_VERSION }} -m venv .venv
-        source .venv/bin/activate
-        make install-ci
     - name: Lint
       run: |
         source .venv/bin/activate
+        make install-ci
         make check
 
   shellcheck:
@@ -83,8 +82,6 @@ jobs:
       if: steps.virtualenv-cache.outputs.cache-hit != 'true'
       run: |
         python${{ env.PYTHON_VERSION }} -m venv .venv
-        source .venv/bin/activate
-        make install-ci
     - name: Install Poppler
       run: |
         sudo apt-get update
@@ -100,6 +97,7 @@ jobs:
         UNSTRUCTURED_HF_TOKEN: ${{ secrets.HF_TOKEN }}
       run: |
         source .venv/bin/activate
+        make install-ci
         aws s3 cp s3://utic-dev-models/ci_test_model/test_ci_model.onnx test_unstructured_inference/models/
         CI=true make test
         make check-coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
-## 0.7.37-dev2
+## 0.7.37-dev3
 
 * refactor: remove layout analysis related code
 * enhancement: Hide warning about table transformer weights not being loaded
 * fix(layout): Use TemporaryDirectory instead of NamedTemporaryFile for Windows support
+* refactor: use `numpy` array to store layout elements' information in one single `LayoutElements`
+  object instead of using a list of `LayoutElement`
 
 ## 0.7.36
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-## 0.7.37-dev1
+## 0.7.37-dev2
 
 * refactor: remove layout analysis related code
 * enhancement: Hide warning about table transformer weights not being loaded
+* fix(layout): Use TemporaryDirectory instead of NamedTemporaryFile for Windows support
 
 ## 0.7.36
 

--- a/Makefile
+++ b/Makefile
@@ -66,14 +66,14 @@ check: check-src check-tests check-version
 .PHONY: check-src
 check-src:
 	ruff ${PACKAGE_NAME} --line-length 100 --select C4,COM,E,F,I,PLR0402,PT,SIM,UP015,UP018,UP032,UP034 --ignore COM812,PT011,PT012,SIM117
-	black --line-length 100 ${PACKAGE_NAME} --check
-	flake8 ${PACKAGE_NAME}
-	mypy ${PACKAGE_NAME} --ignore-missing-imports
+	python -m black --line-length 100 ${PACKAGE_NAME} --check
+	python -m flake8 ${PACKAGE_NAME}
+	python -m mypy ${PACKAGE_NAME} --ignore-missing-imports
 
 .PHONY: check-tests
 check-tests:
-	black --line-length 100 test_${PACKAGE_NAME} --check
-	flake8 test_${PACKAGE_NAME}
+	python -m black --line-length 100 test_${PACKAGE_NAME} --check
+	python -m flake8 test_${PACKAGE_NAME}
 
 ## check-scripts:           run shellcheck
 .PHONY: check-scripts
@@ -105,7 +105,7 @@ version-sync:
 
 .PHONY: check-coverage
 check-coverage:
-	coverage report --fail-under=95
+	python -m coverage report --fail-under=95
 
 ##########
 # Docker #

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ help: Makefile
 ## install-base:            installs core requirements needed for text processing bricks
 .PHONY: install-base
 install-base: install-base-pip-packages
-	pip install -r requirements/base.txt
+	python3 -m pip install -r requirements/base.txt
 
 ## install:                 installs all test, dev, and experimental requirements
 .PHONY: install
@@ -30,11 +30,11 @@ install-base-pip-packages:
 
 .PHONY: install-test
 install-test: install-base
-	pip install -r requirements/test.txt
+	python3 -m pip install -r requirements/test.txt
 
 .PHONY: install-dev
 install-dev: install-test
-	pip install -r requirements/dev.txt
+	python3 -m pip install -r requirements/dev.txt
 
 ## pip-compile:             compiles all base/dev/test requirements
 .PHONY: pip-compile

--- a/test_unstructured_inference/inference/test_layout.py
+++ b/test_unstructured_inference/inference/test_layout.py
@@ -71,7 +71,7 @@ def mock_final_layout():
         type="Title",
     )
 
-    return [text_block, title_block]
+    return layoutelement.LayoutElements.from_list([text_block, title_block])
 
 
 def test_pdf_page_converts_images_to_array(mock_image):
@@ -378,15 +378,41 @@ class MockDetectionModel(layout.UnstructuredObjectDetectionModel):
         pass
 
     def predict(self, x):
-        return [
-            layout.LayoutElement.from_coords(x1=447.0, y1=315.0, x2=1275.7, y2=413.0, text="0"),
-            layout.LayoutElement.from_coords(x1=380.6, y1=473.4, x2=1334.8, y2=533.9, text="1"),
-            layout.LayoutElement.from_coords(x1=578.6, y1=556.8, x2=1109.0, y2=874.4, text="2"),
-            layout.LayoutElement.from_coords(x1=444.5, y1=942.3, x2=1261.1, y2=1584.1, text="3"),
-            layout.LayoutElement.from_coords(x1=444.8, y1=1609.4, x2=1257.2, y2=1665.2, text="4"),
-            layout.LayoutElement.from_coords(x1=414.0, y1=1718.8, x2=635.0, y2=1755.2, text="5"),
-            layout.LayoutElement.from_coords(x1=372.6, y1=1786.9, x2=1333.6, y2=1848.7, text="6"),
-        ]
+        return layoutelement.LayoutElements.from_list(
+            [
+                layout.LayoutElement.from_coords(x1=447.0, y1=315.0, x2=1275.7, y2=413.0, text="0"),
+                layout.LayoutElement.from_coords(x1=380.6, y1=473.4, x2=1334.8, y2=533.9, text="1"),
+                layout.LayoutElement.from_coords(x1=578.6, y1=556.8, x2=1109.0, y2=874.4, text="2"),
+                layout.LayoutElement.from_coords(
+                    x1=444.5,
+                    y1=942.3,
+                    x2=1261.1,
+                    y2=1584.1,
+                    text="3",
+                ),
+                layout.LayoutElement.from_coords(
+                    x1=444.8,
+                    y1=1609.4,
+                    x2=1257.2,
+                    y2=1665.2,
+                    text="4",
+                ),
+                layout.LayoutElement.from_coords(
+                    x1=414.0,
+                    y1=1718.8,
+                    x2=635.0,
+                    y2=1755.2,
+                    text="5",
+                ),
+                layout.LayoutElement.from_coords(
+                    x1=372.6,
+                    y1=1786.9,
+                    x2=1333.6,
+                    y2=1848.7,
+                    text="6",
+                ),
+            ],
+        )
 
 
 def test_layout_order(mock_image):

--- a/test_unstructured_inference/models/test_model.py
+++ b/test_unstructured_inference/models/test_model.py
@@ -2,10 +2,11 @@ import json
 from typing import Any
 from unittest import mock
 
+import numpy as np
 import pytest
 
 import unstructured_inference.models.base as models
-from unstructured_inference.inference.layoutelement import LayoutElement
+from unstructured_inference.inference.layoutelement import LayoutElement, LayoutElements
 from unstructured_inference.models.unstructuredmodel import (
     ModelNotInitializedError,
     UnstructuredObjectDetectionModel,
@@ -23,7 +24,7 @@ class MockModel(UnstructuredObjectDetectionModel):
         return self.initializer(self, *args, **kwargs)
 
     def predict(self, x: Any) -> Any:
-        return []
+        return LayoutElements(element_coords=np.array([]))
 
 
 MOCK_MODEL_TYPES = {

--- a/test_unstructured_inference/models/test_yolox.py
+++ b/test_unstructured_inference/models/test_yolox.py
@@ -15,7 +15,7 @@ def test_layout_yolox_local_parsing_image():
     assert len(document_layout.pages) == 1
     # NOTE(benjamin) The example sent to the test contains 13 detections
     types_known = ["Text", "Section-header", "Page-header"]
-    elements = document_layout.pages[0].elements
+    elements = document_layout.pages[0].elements_array
     known_regions = [
         e for e in elements.element_class_ids if elements.element_class_id_map[e] in types_known
     ]

--- a/test_unstructured_inference/models/test_yolox.py
+++ b/test_unstructured_inference/models/test_yolox.py
@@ -15,14 +15,15 @@ def test_layout_yolox_local_parsing_image():
     assert len(document_layout.pages) == 1
     # NOTE(benjamin) The example sent to the test contains 13 detections
     types_known = ["Text", "Section-header", "Page-header"]
-    known_regions = [e for e in document_layout.pages[0].elements if e.type in types_known]
+    elements = document_layout.pages[0].elements
+    known_regions = [
+        e for e in elements.element_class_ids if elements.element_class_id_map[e] in types_known
+    ]
     assert len(known_regions) == 13
-    assert hasattr(
-        document_layout.pages[0].elements[0],
-        "prob",
-    )  # NOTE(pravin) New Assertion to Make Sure LayoutElement has probabilities
+    # NOTE(pravin) New Assertion to Make Sure LayoutElement has probabilities
+    assert hasattr(elements, "element_probs")
     assert isinstance(
-        document_layout.pages[0].elements[0].prob,
+        elements.element_probs[0],
         float,
     )  # NOTE(pravin) New Assertion to Make Sure Populated Probability is Float
 

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.37-dev1"  # pragma: no cover
+__version__ = "0.7.37-dev2"  # pragma: no cover

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.37-dev2"  # pragma: no cover
+__version__ = "0.7.37-dev3"  # pragma: no cover

--- a/unstructured_inference/inference/elements.py
+++ b/unstructured_inference/inference/elements.py
@@ -218,7 +218,7 @@ class TextRegions:
 
     def slice(self, indices) -> TextRegions:
         return TextRegions(
-            element_coord=self.element_coords[indices],
+            element_coords=self.element_coords[indices],
             texts=self.texts[indices],
             source=self.source,
         )

--- a/unstructured_inference/inference/elements.py
+++ b/unstructured_inference/inference/elements.py
@@ -212,6 +212,17 @@ class TextRegions:
     texts: np.array | None = None
     source: Source | None = None
 
+    def __post_init__(self):
+        if self.texts is None:
+            self.texts = np.array([None] * self.element_coords.shape[0])
+
+    def slice(self, indices) -> TextRegions:
+        return TextRegions(
+            element_coord=self.element_coords[indices],
+            texts=self.texts[indices],
+            source=self.source,
+        )
+
     def as_list(self):
         if self.texts is None:
             return [

--- a/unstructured_inference/inference/elements.py
+++ b/unstructured_inference/inference/elements.py
@@ -217,6 +217,7 @@ class TextRegions:
             self.texts = np.array([None] * self.element_coords.shape[0])
 
     def slice(self, indices) -> TextRegions:
+        """slice text regions based on indices"""
         return TextRegions(
             element_coords=self.element_coords[indices],
             texts=self.texts[indices],
@@ -224,6 +225,7 @@ class TextRegions:
         )
 
     def as_list(self):
+        """return a list of TextRegion objects representing the data"""
         if self.texts is None:
             return [
                 TextRegion.from_coords(x1, y1, x2, y2, None, self.source)
@@ -236,6 +238,8 @@ class TextRegions:
 
     @classmethod
     def from_list(cls, regions: list[TextRegion]):
+        """create TextRegions from a list of TextRegion objects; the objects must have the same
+        source"""
         coords, texts = [], []
         for region in regions:
             coords.append((region.bbox.x1, region.bbox.y1, region.bbox.x2, region.bbox.y2))

--- a/unstructured_inference/inference/elements.py
+++ b/unstructured_inference/inference/elements.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 from dataclasses import dataclass
+from functools import cached_property
 from typing import Optional, Union
 
 import numpy as np
@@ -152,9 +153,15 @@ def intersections(*rects: Rectangle):
     the ijth entry of the matrix is True if and only if the ith Rectangle and jth Rectangle
     intersect."""
     # NOTE(alan): Rewrite using line scan
-    coords = np.stack([[[r.x1, r.y1], [r.x2, r.y2]] for r in rects], axis=-1)
+    coords = np.array([[r.x1, r.y1, r.x2, r.y2] for r in rects])
+    return coords_intersections(coords)
 
-    (x1s, y1s), (x2s, y2s) = coords
+
+def coords_intersections(coords: np.ndarry) -> np.ndarray:
+    """Returns a square boolean matrix of intersections of given stack of coords, i.e.
+    the ijth entry of the matrix is True if and only if the ith coords and jth coords
+    intersect."""
+    x1s, y1s, x2s, y2s = coords[:, 0], coords[:, 1], coords[:, 2], coords[:, 3]
 
     # Use broadcasting to get comparison matrices.
     # For Rectangles r1 and r2, any of the following conditions makes the rectangles disjoint:
@@ -197,6 +204,60 @@ class TextRegion:
         bbox = Rectangle(x1, y1, x2, y2)
 
         return cls(text=text, source=source, bbox=bbox, **kwargs)
+
+
+@dataclass
+class TextRegions:
+    element_coords: np.ndarray
+    texts: np.array | None = None
+    source: Source | None = None
+
+    def as_list(self):
+        if self.texts is None:
+            return [
+                TextRegion.from_coords(x1, y1, x2, y2, None, self.source)
+                for (x1, y1, x2, y2) in self.element_coords
+            ]
+        return [
+            TextRegion.from_coords(x1, y1, x2, y2, text, self.source)
+            for (x1, y1, x2, y2), text in zip(self.element_coords, self.texts)
+        ]
+
+    @classmethod
+    def from_list(cls, regions: list[TextRegion]):
+        coords, texts = [], []
+        for region in regions:
+            coords.append((region.bbox.x1, region.bbox.y1, region.bbox.x2, region.bbox.y2))
+            texts.append(region.text)
+        return cls(element_coords=np.array(coords), texts=np.array(texts), source=regions[0].source)
+
+    def __len__(self):
+        return self.element_coords.shape[0]
+
+    @property
+    def x1(self):
+        """left coordinate"""
+        return self.element_coords[:, 0]
+
+    @property
+    def y1(self):
+        """top coordinate"""
+        return self.element_coords[:, 1]
+
+    @property
+    def x2(self):
+        """right coordinate"""
+        return self.element_coords[:, 2]
+
+    @property
+    def y2(self):
+        """bottom coordinate"""
+        return self.element_coords[:, 3]
+
+    @cached_property
+    def areas(self) -> np.ndarray:
+        """areas of each region; only compute it when it is needed"""
+        return (self.x2 - self.x1) * (self.y2 - self.y1)
 
 
 class EmbeddedTextRegion(TextRegion):

--- a/unstructured_inference/inference/elements.py
+++ b/unstructured_inference/inference/elements.py
@@ -157,7 +157,7 @@ def intersections(*rects: Rectangle):
     return coords_intersections(coords)
 
 
-def coords_intersections(coords: np.ndarry) -> np.ndarray:
+def coords_intersections(coords: np.ndarray) -> np.ndarray:
     """Returns a square boolean matrix of intersections of given stack of coords, i.e.
     the ijth entry of the matrix is True if and only if the ith coords and jth coords
     intersect."""
@@ -209,11 +209,11 @@ class TextRegion:
 @dataclass
 class TextRegions:
     element_coords: np.ndarray
-    texts: np.array | None = None
+    texts: np.ndarray = np.array([])
     source: Source | None = None
 
     def __post_init__(self):
-        if self.texts is None:
+        if self.texts.size == 0 and self.element_coords.size > 0:
             self.texts = np.array([None] * self.element_coords.shape[0])
 
     def slice(self, indices) -> TextRegions:

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import tempfile
+from functools import cached_property
 from pathlib import PurePath
 from typing import Any, BinaryIO, Collection, List, Optional, Union, cast
 
@@ -147,9 +148,14 @@ class PageLayout:
         self.detection_model = detection_model
         self.element_extraction_model = element_extraction_model
         self.elements: Collection[LayoutElement] = []
+        self.elements_array: LayoutElements | None = None
         # NOTE(alan): Dropped LocationlessLayoutElement that was created for chipper - chipper has
         # locations now and if we need to support LayoutElements without bounding boxes we can make
         # the bbox property optional
+
+    @cached_property
+    def elements(self) -> list[LayoutElement]:
+        return self.elements_array.as_list()
 
     def __str__(self) -> str:
         return "\n\n".join([str(element) for element in self.elements])
@@ -173,7 +179,7 @@ class PageLayout:
     def get_elements_with_detection_model(
         self,
         inplace: bool = True,
-    ) -> Optional[List[LayoutElement]]:
+    ) -> LayoutElements | None:
         """Uses specified model to detect the elements on the page."""
         if self.detection_model is None:
             model = get_model()
@@ -191,7 +197,7 @@ class PageLayout:
         )
 
         if inplace:
-            self.elements = inferred_layout
+            self.elements_array = inferred_layout
             return None
 
         return inferred_layout

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import tempfile
 from pathlib import PurePath
-from typing import BinaryIO, Collection, List, Optional, Union, cast
+from typing import Any, BinaryIO, Collection, List, Optional, Union, cast
 
 import numpy as np
 import pdf2image
@@ -323,15 +323,19 @@ class PageLayout:
 def process_data_with_model(
     data: BinaryIO,
     model_name: Optional[str],
-    **kwargs,
+    **kwargs: Any,
 ) -> DocumentLayout:
-    """Processes pdf file in the form of a file handler (supporting a read method) into a
-    DocumentLayout by using a model identified by model_name."""
-    with tempfile.NamedTemporaryFile() as tmp_file:
-        tmp_file.write(data.read())
-        tmp_file.flush()  # Make sure the file is written out
+    """Process PDF as file-like object `data` into a `DocumentLayout`.
+
+    Uses the model identified by `model_name`.
+    """
+    with tempfile.TemporaryDirectory() as tmp_dir_path:
+        file_path = os.path.join(tmp_dir_path, "document.pdf")
+        with open(file_path, "wb") as f:
+            f.write(data.read())
+            f.flush()
         layout = process_file_with_model(
-            tmp_file.name,
+            file_path,
             model_name,
             **kwargs,
         )
@@ -345,7 +349,7 @@ def process_file_with_model(
     is_image: bool = False,
     fixed_layouts: Optional[List[Optional[List[TextRegion]]]] = None,
     pdf_image_dpi: int = 200,
-    **kwargs,
+    **kwargs: Any,
 ) -> DocumentLayout:
     """Processes pdf file with name filename into a DocumentLayout by using a model identified by
     model_name."""

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -177,9 +177,6 @@ class PageLayout:
         array_only: bool = False,
     ) -> Optional[List[LayoutElement]]:
         """Uses specified model to detect the elements on the page."""
-        import pdb
-
-        pdb.set_trace()
         if self.detection_model is None:
             model = get_model()
             if isinstance(model, UnstructuredObjectDetectionModel):

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -12,9 +12,7 @@ from PIL import Image, ImageSequence
 from unstructured_inference.inference.elements import (
     TextRegion,
 )
-from unstructured_inference.inference.layoutelement import (
-    LayoutElement,
-)
+from unstructured_inference.inference.layoutelement import LayoutElement, LayoutElements
 from unstructured_inference.logger import logger
 from unstructured_inference.models.base import get_model
 from unstructured_inference.models.unstructuredmodel import (
@@ -187,7 +185,7 @@ class PageLayout:
         # NOTE(mrobinson) - We'll want make this model inference step some kind of
         # remote call in the future.
         assert self.image is not None
-        inferred_layout: List[LayoutElement] = self.detection_model(self.image)
+        inferred_layout: LayoutElements = self.detection_model(self.image)
         inferred_layout = self.detection_model.deduplicate_detected_elements(
             inferred_layout,
         )

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 import tempfile
-from functools import cached_property
 from pathlib import PurePath
 from typing import Any, BinaryIO, Collection, List, Optional, Union, cast
 
@@ -153,10 +152,6 @@ class PageLayout:
         # locations now and if we need to support LayoutElements without bounding boxes we can make
         # the bbox property optional
 
-    @cached_property
-    def elements(self) -> list[LayoutElement]:
-        return self.elements_array.as_list()
-
     def __str__(self) -> str:
         return "\n\n".join([str(element) for element in self.elements])
 
@@ -179,8 +174,12 @@ class PageLayout:
     def get_elements_with_detection_model(
         self,
         inplace: bool = True,
-    ) -> LayoutElements | None:
+        array_only: bool = False,
+    ) -> Optional[List[LayoutElement]]:
         """Uses specified model to detect the elements on the page."""
+        import pdb
+
+        pdb.set_trace()
         if self.detection_model is None:
             model = get_model()
             if isinstance(model, UnstructuredObjectDetectionModel):
@@ -198,9 +197,11 @@ class PageLayout:
 
         if inplace:
             self.elements_array = inferred_layout
+            if not array_only:
+                self.elements = inferred_layout.as_list()
             return None
 
-        return inferred_layout
+        return inferred_layout.as_list()
 
     def _get_image_array(self) -> Union[np.ndarray, None]:
         """Converts the raw image into a numpy array."""

--- a/unstructured_inference/inference/layoutelement.py
+++ b/unstructured_inference/inference/layoutelement.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Collection, Iterable, List, Optional
+from typing import Any, Collection, Iterable, List, Optional
 
 import numpy as np
 from layoutparser.elements.layout import TextBlock
@@ -89,7 +89,7 @@ class LayoutElements(TextRegions):
             source=group.source,
         )
 
-    def as_list(self) -> list[LayoutElement]:
+    def as_list(self):
         """return a list of LayoutElement for backward compatibility"""
         return [
             LayoutElement.from_coords(
@@ -407,7 +407,7 @@ def clean_layoutelements(elements: LayoutElements, subregion_threshold: float = 
     final_coords = sorted_coords[mask]
     sorted_by_y1 = np.argsort(final_coords[:, 1])
 
-    final_attrs = {"element_class_id_map": elements.element_class_id_map}
+    final_attrs: dict[str, Any] = {"element_class_id_map": elements.element_class_id_map}
     for attr in ("element_class_ids", "element_probs", "texts"):
         if (original_attr := getattr(elements, attr)) is None:
             continue
@@ -483,7 +483,7 @@ def clean_layoutelements_for_class(
     other_mask = ~other_is_almost_subregion_of_target.sum(axis=1).astype(bool)
 
     final_coords = np.vstack([target_coords[mask], other_coords[other_mask]])
-    final_attrs = {"element_class_id_map": elements.element_class_id_map}
+    final_attrs: dict[str, Any] = {"element_class_id_map": elements.element_class_id_map}
     for attr in ("element_class_ids", "element_probs", "texts"):
         if (original_attr := getattr(elements, attr)) is None:
             continue

--- a/unstructured_inference/inference/layoutelement.py
+++ b/unstructured_inference/inference/layoutelement.py
@@ -98,9 +98,11 @@ class LayoutElements(TextRegions):
                 x2,
                 y2,
                 text=text,
-                type=self.element_class_id_map[class_id]
-                if class_id and self.element_class_id_map
-                else None,
+                type=(
+                    self.element_class_id_map[class_id]
+                    if class_id and self.element_class_id_map
+                    else None
+                ),
                 prob=prob,
                 source=self.source,
             )

--- a/unstructured_inference/inference/layoutelement.py
+++ b/unstructured_inference/inference/layoutelement.py
@@ -35,6 +35,8 @@ class LayoutElements(TextRegions):
     element_class_id_map: dict[int, str] | None = None
 
     def __post_init__(self):
+        if self.element_probs is not None:
+            self.element_probs = self.element_probs.astype(float)
         for attr in ("element_probs", "element_class_ids", "texts"):
             if getattr(self, attr) is None:
                 setattr(self, attr, np.array([None] * self.element_coords.shape[0]))
@@ -70,10 +72,6 @@ class LayoutElements(TextRegions):
 
     def as_list(self) -> list[LayoutElement]:
         """for backward compatibility"""
-        len_elements = self.element_coords.shape[0]
-        texts = self.texts or [None] * len_elements
-        element_class_ids = self.element_class_ids or [None] * len_elements
-        element_probs = self.element_probs or [None] * len_elements
         return [
             LayoutElement.from_coords(
                 x1,
@@ -89,9 +87,9 @@ class LayoutElements(TextRegions):
             )
             for (x1, y1, x2, y2), text, prob, class_id in zip(
                 self.element_coords,
-                texts,
-                element_probs,
-                element_class_ids,
+                self.texts,
+                self.element_probs,
+                self.element_class_ids,
             )
         ]
 

--- a/unstructured_inference/inference/layoutelement.py
+++ b/unstructured_inference/inference/layoutelement.py
@@ -60,7 +60,8 @@ class LayoutElements(TextRegions):
             texts.append(group.texts)
             probs.append(group.element_probs)
             class_ids.append(group.element_class_ids)
-            class_id_map.update(group.element_class_id_map)
+            if group.element_class_id_map:
+                class_id_map.update(group.element_class_id_map)
         return cls(
             element_coords=np.concatenate(coords),
             texts=np.concatenate(texts),
@@ -456,10 +457,10 @@ def clean_layoutelements_for_class(
         target_coords_to_keep,
     )
     # check from largest to smallest regions to find if it contains any other regions
+    other_areas = elements.areas[sorted_by_area][~target_indices]
     other_is_almost_subregion_of_target = (
-        other_to_target_intersection / np.maximum(target_areas[mask], EPSILON_AREA)
-        > subregion_threshold
-    ) & (elements.areas[sorted_by_area][~target_indices].reshape((-1, 1)) <= target_areas.T)
+        other_to_target_intersection / np.maximum(other_areas, EPSILON_AREA) > subregion_threshold
+    ) & (other_areas.reshape((-1, 1)) <= target_areas[mask].T)
 
     other_mask = ~other_is_almost_subregion_of_target.sum(axis=1).astype(bool)
 

--- a/unstructured_inference/inference/layoutelement.py
+++ b/unstructured_inference/inference/layoutelement.py
@@ -19,10 +19,47 @@ from unstructured_inference.inference.elements import (
     ImageTextRegion,
     Rectangle,
     TextRegion,
+    TextRegions,
+    coords_intersections,
     grow_region_to_match_region,
-    intersections,
     region_bounding_boxes_are_almost_the_same,
 )
+
+EPSILON_AREA = 1e-7
+
+
+@dataclass
+class LayoutElements(TextRegions):
+    element_probs: np.ndarray | None = None
+    element_class_ids: np.ndarray | None = None
+    element_class_id_map: dict[int, str] | None = None
+
+    def as_list(self) -> list[LayoutElement]:
+        """for backward compatibility"""
+        len_elements = self.element_coords.shape[0]
+        texts = self.texts or [None] * len_elements
+        element_class_ids = self.element_class_ids or [None] * len_elements
+        element_probs = self.element_probs or [None] * len_elements
+        return [
+            LayoutElement.from_coords(
+                x1,
+                y1,
+                x2,
+                y2,
+                text=text,
+                type=self.element_class_id_map[class_id]
+                if class_id and self.element_class_id_map
+                else None,
+                prob=prob,
+                source=self.source,
+            )
+            for (x1, y1, x2, y2), text, prob, class_id in zip(
+                self.element_coords,
+                texts,
+                element_probs,
+                element_class_ids,
+            )
+        ]
 
 
 @dataclass
@@ -215,7 +252,10 @@ def separate(region_a: Rectangle, region_b: Rectangle):
 
 
 def table_cells_to_dataframe(
-    cells: List[dict], nrows: int = 1, ncols: int = 1, header=None
+    cells: List[dict],
+    nrows: int = 1,
+    ncols: int = 1,
+    header=None,
 ) -> DataFrame:
     """convert table-transformer's cells data into a pandas dataframe"""
     arr = np.empty((nrows, ncols), dtype=object)
@@ -232,23 +272,179 @@ def table_cells_to_dataframe(
     return DataFrame(arr, columns=header)
 
 
-def partition_groups_from_regions(regions: Collection[TextRegion]) -> List[List[TextRegion]]:
+def partition_groups_from_regions(regions: TextRegions) -> List[TextRegions]:
     """Partitions regions into groups of regions based on proximity. Returns list of lists of
     regions, each list corresponding with a group"""
     if len(regions) == 0:
         return []
-    padded_regions = [
-        r.bbox.vpad(r.bbox.height * inference_config.ELEMENTS_V_PADDING_COEF).hpad(
-            r.bbox.height * inference_config.ELEMENTS_H_PADDING_COEF,
+    padded_coords = regions.element_coords.copy()
+    v_pad = (regions.y2 - regions.y1) * inference_config.ELEMENTS_V_PADDING_COEF
+    h_pad = (regions.x2 - regions.x1) * inference_config.ELEMENTS_H_PADDING_COEF
+    padded_coords[:, 0] -= h_pad
+    padded_coords[:, 1] -= v_pad
+    padded_coords[:, 2] += h_pad
+    padded_coords[:, 3] += v_pad
+
+    intersection_mtx = coords_intersections(padded_coords)
+
+    group_count, group_nums = connected_components(intersection_mtx)
+    groups: List[TextRegions] = []
+    for group in range(group_count):
+        indices = np.where(group_nums == group)[0]
+        groups.append(
+            TextRegions(
+                element_coords=regions.element_coords[indices],
+                texts=regions.texts[indices],
+                source=regions.source,
+            ),
         )
-        for r in regions
-    ]
-
-    intersection_mtx = intersections(*padded_regions)
-
-    _, group_nums = connected_components(intersection_mtx)
-    groups: List[List[TextRegion]] = [[] for _ in range(max(group_nums) + 1)]
-    for region, group_num in zip(regions, group_nums):
-        groups[group_num].append(region)
 
     return groups
+
+
+def intersection_areas_between_coords(
+    coords1: np.ndarray,
+    coords2: np.ndarray,
+    threshold: float = 0.5,
+):
+    """compute intersection area and own areas for two groups of bounding boxes"""
+    x11, y11, x12, y12 = np.split(coords1, 4, axis=1)
+    x21, y21, x22, y22 = np.split(coords2, 4, axis=1)
+
+    xa = np.maximum(x11, np.transpose(x21))
+    ya = np.maximum(y11, np.transpose(y21))
+    xb = np.minimum(x12, np.transpose(x22))
+    yb = np.minimum(y12, np.transpose(y22))
+
+    return np.maximum((xb - xa), 0) * np.maximum((yb - ya), 0)
+
+
+def clean_layoutelements(elements: LayoutElements, subregion_threshold: float = 0.5):
+    """After this function, the list of elements will not contain any element inside
+    of the type specified"""
+    # Sort elements from biggest to smallest
+    if len(elements) < 2:
+        return elements
+
+    sorted_by_area = np.argsort(-elements.areas)
+    sorted_coords = elements.element_coords[sorted_by_area]
+
+    # First check if targets contains each other
+    self_intersection = intersection_areas_between_coords(sorted_coords, sorted_coords)
+    areas = elements.areas[sorted_by_area]
+    # check from largest to smallest regions to find if it contains any other regions
+    is_almost_subregion_of = (
+        self_intersection / np.maximum(areas, EPSILON_AREA) > subregion_threshold
+    ) & (areas <= areas.T)
+
+    n_candidates = len(elements)
+    mask = np.ones_like(areas, dtype=bool)
+    current_candidate = 0
+    while n_candidates > 1:
+        plus_one = current_candidate + 1
+        remove = (
+            np.where(is_almost_subregion_of[current_candidate, plus_one:])[0]
+            + current_candidate
+            + 1
+        )
+
+        if not remove.sum():
+            break
+
+        mask[remove] = 0
+        n_candidates -= len(remove) + 1
+        remaining_candidates = np.where(mask[plus_one:])[0]
+
+        if not len(remaining_candidates):
+            break
+
+        current_candidate = remaining_candidates[0] + plus_one
+
+    final_coords = sorted_coords[mask]
+    sorted_by_y1 = np.argsort(final_coords[:, 1])
+
+    final_attrs = {"element_class_id_map": elements.element_class_id_map}
+    for attr in ("element_class_ids", "element_probs", "texts"):
+        if (original_attr := getattr(elements, attr)) is None:
+            continue
+        final_attrs[attr] = original_attr[sorted_by_area][mask][sorted_by_y1]
+    final_elements = LayoutElements(element_coords=final_coords[sorted_by_y1], **final_attrs)
+    return final_elements
+
+
+def clean_layoutelements_for_class(
+    elements: LayoutElements,
+    element_class: int,
+    subregion_threshold: float = 0.5,
+):
+    """After this function, the list of elements will not contain any element inside
+    of the type specified"""
+    # Sort elements from biggest to smallest
+    sorted_by_area = np.argsort(-elements.areas)
+    sorted_coords = elements.element_coords[sorted_by_area]
+
+    target_indices = elements.element_class_ids[sorted_by_area] == element_class
+
+    # skip trivial result
+    len_target = target_indices.sum()
+    if len_target == 0 or len_target == len(elements):
+        return elements
+
+    target_coords = sorted_coords[target_indices]
+    other_coords = sorted_coords[~target_indices]
+
+    # First check if targets contains each other
+    target_self_intersection = intersection_areas_between_coords(target_coords, target_coords)
+    target_areas = elements.areas[sorted_by_area][target_indices]
+    # check from largest to smallest regions to find if it contains any other regions
+    is_almost_subregion_of = (
+        target_self_intersection / np.maximum(target_areas, EPSILON_AREA) > subregion_threshold
+    ) & (target_areas <= target_areas.T)
+
+    n_candidates = len_target
+    mask = np.ones_like(target_areas, dtype=bool)
+    current_candidate = 0
+    while n_candidates > 1:
+        plus_one = current_candidate + 1
+        remove = (
+            np.where(is_almost_subregion_of[current_candidate, plus_one:])[0]
+            + current_candidate
+            + 1
+        )
+
+        if not remove.sum():
+            break
+
+        mask[remove] = 0
+        n_candidates -= len(remove) + 1
+        remaining_candidates = np.where(mask[plus_one:])[0]
+
+        if not len(remaining_candidates):
+            break
+
+        current_candidate = remaining_candidates[0] + plus_one
+
+    target_coords_to_keep = target_coords[mask]
+
+    other_to_target_intersection = intersection_areas_between_coords(
+        other_coords,
+        target_coords_to_keep,
+    )
+    # check from largest to smallest regions to find if it contains any other regions
+    other_is_almost_subregion_of_target = (
+        other_to_target_intersection / np.maximum(target_areas[mask], EPSILON_AREA)
+        > subregion_threshold
+    ) & (elements.areas[sorted_by_area][~target_indices].reshape((-1, 1)) <= target_areas.T)
+
+    other_mask = ~other_is_almost_subregion_of_target.sum(axis=1).astype(bool)
+
+    final_coords = np.vstack([target_coords[mask], other_coords[other_mask]])
+    final_attrs = {"element_class_id_map": elements.element_class_id_map}
+    for attr in ("element_class_ids", "element_probs", "texts"):
+        if (original_attr := getattr(elements, attr)) is None:
+            continue
+        final_attrs[attr] = np.concatenate(
+            (original_attr[target_indices][mask], original_attr[~target_indices][other_mask]),
+        )
+    final_elements = LayoutElements(element_coords=final_coords, **final_attrs)
+    return final_elements

--- a/unstructured_inference/inference/layoutelement.py
+++ b/unstructured_inference/inference/layoutelement.py
@@ -53,21 +53,6 @@ class LayoutElements(TextRegions):
             element_class_id_map=self.element_class_id_map,
         )
 
-    def __iter__(self, idx) -> LayoutElement:
-        x1, y1, x2, y2 = self.element_coords[idx]
-        etype = (
-            self.element_class_id_map[self.element_class_ids[idx]]
-            if self.element_class_id_map
-            else None
-        )
-        return LayoutElement(
-            Rectangle(x1=x1, y1=y1, x2=x2, y2=y2),
-            text=self.texts[idx],
-            source=self.source,
-            type=etype,
-            prob=self.element_probs[idx],
-        )
-
     @classmethod
     def concatenate(cls, groups: Iterable[LayoutElements]) -> LayoutElements:
         """concatenate a sequence of LayoutElements in order as one LayoutElements"""

--- a/unstructured_inference/inference/layoutelement.py
+++ b/unstructured_inference/inference/layoutelement.py
@@ -42,6 +42,7 @@ class LayoutElements(TextRegions):
                 setattr(self, attr, np.array([None] * self.element_coords.shape[0]))
 
     def slice(self, indices) -> LayoutElements:
+        """slice and return only selected indices"""
         return LayoutElements(
             element_coords=self.element_coords[indices],
             texts=self.texts[indices],
@@ -53,6 +54,7 @@ class LayoutElements(TextRegions):
 
     @classmethod
     def concatenate(cls, groups: Iterable[LayoutElements]) -> LayoutElements:
+        """concatenate a sequence of LayoutElements in order as one LayoutElements"""
         coords, texts, probs, class_ids = [], [], [], []
         class_id_map = {}
         for group in groups:
@@ -72,7 +74,7 @@ class LayoutElements(TextRegions):
         )
 
     def as_list(self) -> list[LayoutElement]:
-        """for backward compatibility"""
+        """return a list of LayoutElement for backward compatibility"""
         return [
             LayoutElement.from_coords(
                 x1,

--- a/unstructured_inference/models/base.py
+++ b/unstructured_inference/models/base.py
@@ -20,12 +20,10 @@ DEFAULT_MODEL = "yolox"
 models: Dict[str, UnstructuredModel] = {}
 
 
-def get_default_model_mappings() -> (
-    Tuple[
-        Dict[str, Type[UnstructuredModel]],
-        Dict[str, dict | LazyDict],
-    ]
-):
+def get_default_model_mappings() -> Tuple[
+    Dict[str, Type[UnstructuredModel]],
+    Dict[str, dict | LazyDict],
+]:
     """default model mappings for models that are in `unstructured_inference` repo"""
     return {
         **{name: UnstructuredDetectronONNXModel for name in DETECTRON2_ONNX_MODEL_TYPES},

--- a/unstructured_inference/models/base.py
+++ b/unstructured_inference/models/base.py
@@ -6,7 +6,9 @@ from typing import Dict, Optional, Tuple, Type
 
 from unstructured_inference.models.chipper import MODEL_TYPES as CHIPPER_MODEL_TYPES
 from unstructured_inference.models.chipper import UnstructuredChipperModel
-from unstructured_inference.models.detectron2onnx import MODEL_TYPES as DETECTRON2_ONNX_MODEL_TYPES
+from unstructured_inference.models.detectron2onnx import (
+    MODEL_TYPES as DETECTRON2_ONNX_MODEL_TYPES,
+)
 from unstructured_inference.models.detectron2onnx import UnstructuredDetectronONNXModel
 from unstructured_inference.models.unstructuredmodel import UnstructuredModel
 from unstructured_inference.models.yolox import MODEL_TYPES as YOLOX_MODEL_TYPES
@@ -18,10 +20,12 @@ DEFAULT_MODEL = "yolox"
 models: Dict[str, UnstructuredModel] = {}
 
 
-def get_default_model_mappings() -> Tuple[
-    Dict[str, Type[UnstructuredModel]],
-    Dict[str, dict | LazyDict],
-]:
+def get_default_model_mappings() -> (
+    Tuple[
+        Dict[str, Type[UnstructuredModel]],
+        Dict[str, dict | LazyDict],
+    ]
+):
     """default model mappings for models that are in `unstructured_inference` repo"""
     return {
         **{name: UnstructuredDetectronONNXModel for name in DETECTRON2_ONNX_MODEL_TYPES},

--- a/unstructured_inference/models/unstructuredmodel.py
+++ b/unstructured_inference/models/unstructuredmodel.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, List, cast
+from typing import Any, List
 
 import numpy as np
 from PIL.Image import Image
@@ -12,16 +12,12 @@ from unstructured_inference.inference.elements import (
     intersections,
 )
 from unstructured_inference.inference.layoutelement import (
+    LayoutElement,
+    LayoutElements,
     clean_layoutelements,
     partition_groups_from_regions,
     separate,
 )
-
-if TYPE_CHECKING:
-    from unstructured_inference.inference.layoutelement import (
-        LayoutElement,
-        LayoutElements,
-    )
 
 
 class UnstructuredModel(ABC):
@@ -181,15 +177,14 @@ class UnstructuredObjectDetectionModel(UnstructuredModel):
         if len(elements) <= 1:
             return elements
 
-        cleaned_elements: LayoutElements = []
+        cleaned_elements = []
         # TODO: Delete nested elements with low or None probability
         # TODO: Keep most confident
         # TODO: Better to grow horizontally than vertically?
-        groups_tmp = partition_groups_from_regions(elements)
-        groups = cast(List[LayoutElements], groups_tmp)
-        for elements in groups:
-            cleaned_elements.extend(clean_layoutelements(elements))
-        return cleaned_elements
+        groups = partition_groups_from_regions(elements)
+        for group in groups:
+            cleaned_elements.append(clean_layoutelements(group))
+        return LayoutElements.concatenate(cleaned_elements)
 
 
 class UnstructuredElementExtractionModel(UnstructuredModel):

--- a/unstructured_inference/models/unstructuredmodel.py
+++ b/unstructured_inference/models/unstructuredmodel.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, List
+from typing import Any, List, cast
 
 import numpy as np
 from PIL.Image import Image
@@ -54,10 +54,10 @@ class UnstructuredObjectDetectionModel(UnstructuredModel):
     """Wrapper class for object detection models used by unstructured."""
 
     @abstractmethod
-    def predict(self, x: Image) -> LayoutElements:
+    def predict(self, x: Image) -> LayoutElements | list[LayoutElement]:
         """Do inference using the wrapped model."""
         super().predict(x)
-        return []  # pragma: no cover
+        return []
 
     def __call__(self, x: Image) -> LayoutElements:
         """Inference using function call interface."""
@@ -128,7 +128,7 @@ class UnstructuredObjectDetectionModel(UnstructuredModel):
 
     @staticmethod
     def clean_type(
-        elements: LayoutElements,
+        elements: list[LayoutElement],
         type_to_clean=ElementType.TABLE,
     ) -> List[LayoutElement]:
         """After this function, the list of elements will not contain any element inside
@@ -181,7 +181,7 @@ class UnstructuredObjectDetectionModel(UnstructuredModel):
         # TODO: Delete nested elements with low or None probability
         # TODO: Keep most confident
         # TODO: Better to grow horizontally than vertically?
-        groups = partition_groups_from_regions(elements)
+        groups = cast(list[LayoutElements], partition_groups_from_regions(elements))
         for group in groups:
             cleaned_elements.append(clean_layoutelements(group))
         return LayoutElements.concatenate(cleaned_elements)

--- a/unstructured_inference/models/unstructuredmodel.py
+++ b/unstructured_inference/models/unstructuredmodel.py
@@ -54,12 +54,12 @@ class UnstructuredObjectDetectionModel(UnstructuredModel):
     """Wrapper class for object detection models used by unstructured."""
 
     @abstractmethod
-    def predict(self, x: Image) -> List[LayoutElement]:
+    def predict(self, x: Image) -> LayoutElements:
         """Do inference using the wrapped model."""
         super().predict(x)
         return []  # pragma: no cover
 
-    def __call__(self, x: Image) -> List[LayoutElement]:
+    def __call__(self, x: Image) -> LayoutElements:
         """Inference using function call interface."""
         return super().__call__(x)
 

--- a/unstructured_inference/models/unstructuredmodel.py
+++ b/unstructured_inference/models/unstructuredmodel.py
@@ -11,10 +11,17 @@ from unstructured_inference.inference.elements import (
     grow_region_to_match_region,
     intersections,
 )
-from unstructured_inference.inference.layoutelement import partition_groups_from_regions, separate
+from unstructured_inference.inference.layoutelement import (
+    clean_layoutelements,
+    partition_groups_from_regions,
+    separate,
+)
 
 if TYPE_CHECKING:
-    from unstructured_inference.inference.layoutelement import LayoutElement
+    from unstructured_inference.inference.layoutelement import (
+        LayoutElement,
+        LayoutElements,
+    )
 
 
 class UnstructuredModel(ABC):
@@ -125,7 +132,8 @@ class UnstructuredObjectDetectionModel(UnstructuredModel):
 
     @staticmethod
     def clean_type(
-        elements: List[LayoutElement], type_to_clean=ElementType.TABLE
+        elements: LayoutElements,
+        type_to_clean=ElementType.TABLE,
     ) -> List[LayoutElement]:
         """After this function, the list of elements will not contain any element inside
         of the type specified"""
@@ -165,25 +173,22 @@ class UnstructuredObjectDetectionModel(UnstructuredModel):
 
     def deduplicate_detected_elements(
         self,
-        elements: List[LayoutElement],
+        elements: LayoutElements,
         min_text_size: int = 15,
-    ) -> List[LayoutElement]:
+    ) -> LayoutElements:
         """Deletes overlapping elements in a list of elements."""
 
         if len(elements) <= 1:
             return elements
 
-        cleaned_elements: List[LayoutElement] = []
+        cleaned_elements: LayoutElements = []
         # TODO: Delete nested elements with low or None probability
         # TODO: Keep most confident
         # TODO: Better to grow horizontally than vertically?
         groups_tmp = partition_groups_from_regions(elements)
-        groups = cast(List[List["LayoutElement"]], groups_tmp)
-        for g in groups:
-            all_types = {e.type for e in g}
-            for type in all_types:
-                g = UnstructuredObjectDetectionModel.clean_type(g, type)
-            cleaned_elements.extend(g)
+        groups = cast(List[LayoutElements], groups_tmp)
+        for elements in groups:
+            cleaned_elements.extend(clean_layoutelements(elements))
         return cleaned_elements
 
 


### PR DESCRIPTION
This PR adds two new vectorized page level dataclasses:
- `TextRegions`: replaces a `list[TextRegion]` and store coordinates and texts as numpy arrays for more efficient memory operations when the number of items is large
- `LayoutElements`: replaces a `list[LayoutElement]` and store data in numpy arrays as above
In addition this PR refactors `yolox` model inference to use those two new classes above internally while keeping the list data structure still available for backward compatibility (e.g., passing into a `PageLayout` object). 

## test

compare memory usage and runtime on a pdf image using

```python
from unstructured_inference.inference.layout import process_file_with_model


def main():
    f = "/Users/yaoyou/Downloads/002489.pdf"
    layout = process_file_with_model(f, model_name="yolox")
    # replace elements_array with elements when using main branch
    print(f"fount {len(layout.pages[0].elements_array)} elements")


if __name__ == "__main__":
    main()
```

The peak memory is smaller on this branch (exact amount depends on the number of layout elements detected) and processing time is slightly faster (since this PR skips generation of list of `LayoutElement` from numpy array output of the yolox model).