### PR TITLE
fix: invalid dataclass mutable default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.38-dev0
+
+* fix: Correctly assign mutable default value to variable in `TextRegions` class
+
 ## 0.7.37
 
 * refactor: remove layout analysis related code

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.37"  # pragma: no cover
+__version__ = "0.7.38-dev0"  # pragma: no cover

--- a/unstructured_inference/inference/elements.py
+++ b/unstructured_inference/inference/elements.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import cached_property
 from typing import Optional, Union
 
@@ -209,7 +209,7 @@ class TextRegion:
 @dataclass
 class TextRegions:
     element_coords: np.ndarray
-    texts: np.ndarray = np.array([])
+    texts: np.ndarray = field(default_factory=lambda: np.array([]))
     source: Source | None = None
 
     def __post_init__(self):


### PR DESCRIPTION
Importing `TextRegion` from `unstructured_inference.inference.elements` causes the following error
```
  File "<stdin>", line 1, in <module>
  File "/home/filip/Unstructured/unstructured-inference/unstructured_inference/inference/elements.py", line 209, in <module>
    @dataclass
     ^^^^^^^^^
  File "/home/filip/.pyenv/versions/3.12.1/lib/python3.12/dataclasses.py", line 1266, in dataclass
    return wrap(cls)
           ^^^^^^^^^
  File "/home/filip/.pyenv/versions/3.12.1/lib/python3.12/dataclasses.py", line 1256, in wrap
    return _process_class(cls, init, repr, eq, order, unsafe_hash,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/filip/.pyenv/versions/3.12.1/lib/python3.12/dataclasses.py", line 994, in _process_class
    cls_fields.append(_get_field(cls, name, type, kw_only))
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/filip/.pyenv/versions/3.12.1/lib/python3.12/dataclasses.py", line 852, in _get_field
    raise ValueError(f'mutable default {type(f.default)} for field '
ValueError: mutable default <class 'numpy.ndarray'> for field texts is not allowed: use default_factory
```
this PR modifies the default value to be assigned via `default_factory` as instructed.