### PR TITLE
use field to set default empty array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.39
+
+* fix: Correctly assign mutable default value to variable in `LayoutElements` class
+
 ## 0.7.38
 
 * fix: Correctly assign mutable default value to variable in `TextRegions` class

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.38"  # pragma: no cover
+__version__ = "0.7.39"  # pragma: no cover

--- a/unstructured_inference/inference/layoutelement.py
+++ b/unstructured_inference/inference/layoutelement.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Collection, Iterable, List, Optional
 
 import numpy as np
@@ -30,8 +30,8 @@ EPSILON_AREA = 1e-7
 
 @dataclass
 class LayoutElements(TextRegions):
-    element_probs: np.ndarray = np.array([])
-    element_class_ids: np.ndarray = np.array([])
+    element_probs: np.ndarray = field(default_factory=lambda: np.array([]))
+    element_class_ids: np.ndarray = field(default_factory=lambda: np.array([]))
     element_class_id_map: dict[int, str] | None = None
 
     def __post_init__(self):


### PR DESCRIPTION
Fix an issue where numpy array is used as default value to dataclass attribute. Similar to https://github.com/Unstructured-IO/unstructured-inference/pull/388 but for the LayoutElements class