### PR TITLE
fix: fix bugs in layoutelements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.7.41
+
+* fix: fix incorrect type casting with higher versions of `numpy` when substracting a `float` from an `int` array
+* fix: fix a bug where class id 0 becomes class type `None` when calling `LayoutElements.as_list()`
+
 ## 0.7.40
 
 * fix: store probabilities with `float` data type instead of `int`

--- a/test_unstructured_inference/test_elements.py
+++ b/test_unstructured_inference/test_elements.py
@@ -421,3 +421,14 @@ def test_clean_layoutelements_for_class(
     elements = clean_layoutelements_for_class(elements, element_class=class_to_filter)
     np.testing.assert_array_equal(elements.element_coords, expected_coords)
     np.testing.assert_array_equal(elements.element_class_ids, expected_ids)
+
+
+def test_layoutelements_to_list_and_back(test_layoutelements):
+    back = LayoutElements.from_list(test_layoutelements.as_list())
+    np.testing.assert_array_equal(test_layoutelements.element_coords, back.element_coords)
+    np.testing.assert_array_equal(test_layoutelements.texts, back.texts)
+    assert all(np.isnan(back.element_probs))
+    assert [
+        test_layoutelements.element_class_id_map[idx]
+        for idx in test_layoutelements.element_class_ids
+    ] == [back.element_class_id_map[idx] for idx in back.element_class_ids]

--- a/test_unstructured_inference/test_elements.py
+++ b/test_unstructured_inference/test_elements.py
@@ -143,8 +143,10 @@ def test_minimal_containing_rect():
         assert rect2.is_in(big_rect)
 
 
-def test_partition_groups_from_regions(mock_embedded_text_regions):
+@pytest.mark.parametrize("coord_type", [int, float])
+def test_partition_groups_from_regions(mock_embedded_text_regions, coord_type):
     words = TextRegions.from_list(mock_embedded_text_regions)
+    words.element_coords = words.element_coords.astype(coord_type)
     groups = partition_groups_from_regions(words)
     assert len(groups) == 1
     text = "".join(groups[-1].texts)

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.40"  # pragma: no cover
+__version__ = "0.7.41"  # pragma: no cover

--- a/unstructured_inference/inference/elements.py
+++ b/unstructured_inference/inference/elements.py
@@ -237,7 +237,7 @@ class TextRegions:
         ]
 
     @classmethod
-    def from_list(cls, regions: list[TextRegion]):
+    def from_list(cls, regions: list):
         """create TextRegions from a list of TextRegion objects; the objects must have the same
         source"""
         coords, texts = [], []

--- a/unstructured_inference/inference/layoutelement.py
+++ b/unstructured_inference/inference/layoutelement.py
@@ -99,7 +99,7 @@ class LayoutElements(TextRegions):
         ]
 
     @classmethod
-    def from_list(cls, elements: list[LayoutElement]):
+    def from_list(cls, elements: list):
         """create LayoutElements from a list of LayoutElement objects; the objects must have the
         same source"""
         len_ele = len(elements)

--- a/unstructured_inference/inference/layoutelement.py
+++ b/unstructured_inference/inference/layoutelement.py
@@ -100,8 +100,8 @@ class LayoutElements(TextRegions):
 
     @classmethod
     def from_list(cls, elements: list[LayoutElement]):
-        """create LayoutElements from a list of LayoutElement objects; the objects must have the same
-        source"""
+        """create LayoutElements from a list of LayoutElement objects; the objects must have the
+        same source"""
         len_ele = len(elements)
         coords = np.empty((len_ele, 4), dtype=float)
         # text and probs can be Nones so use lists first then convert into array to avoid them being

--- a/unstructured_inference/inference/layoutelement.py
+++ b/unstructured_inference/inference/layoutelement.py
@@ -32,7 +32,7 @@ EPSILON_AREA = 1e-7
 class LayoutElements(TextRegions):
     element_probs: np.ndarray = field(default_factory=lambda: np.array([]))
     element_class_ids: np.ndarray = field(default_factory=lambda: np.array([]))
-    element_class_id_map: dict[int, str] | None = None
+    element_class_id_map: dict[int, str] = field(default_factory=dict)
 
     def __post_init__(self):
         element_size = self.element_coords.shape[0]
@@ -42,7 +42,10 @@ class LayoutElements(TextRegions):
 
         self.element_probs = self.element_probs.astype(float)
 
-    def __eq__(self, other: LayoutElements) -> bool:
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, LayoutElements):
+            return NotImplemented
+
         mask = ~np.isnan(self.element_probs)
         other_mask = ~np.isnan(other.element_probs)
         return (

--- a/unstructured_inference/models/yolox.py
+++ b/unstructured_inference/models/yolox.py
@@ -136,7 +136,7 @@ class UnstructuredYoloXModel(UnstructuredObjectDetectionModel):
         sorted_dets = dets[order]
 
         return LayoutElements(
-            element_coords=sorted_dets[:, :4],
+            element_coords=sorted_dets[:, :4].astype(float),
             element_probs=sorted_dets[:, 4].astype(float),
             element_class_ids=sorted_dets[:, 5].astype(int),
             element_class_id_map=self.layout_classes,


### PR DESCRIPTION
This PR fixes two bugs:

- fix a type casting issue when subtracting a int array with a float. This popped up when testing with `unstructured`, and some sources of element coordinates are of `int` type. This PR adds a new unit test case for `int` coord type with the grouping function
- fix element class id 0 becomes None bug: this happens when dumping `LayoutElements` as a list of `LayoutElement`. When an element class id is 0 the logic on main would treat it as no existing and use `None` as the type.