### PR TITLE
feat: support download modal from modelscope

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ The inference pipeline operates by finding text elements in a document page usin
 
 We offer several detection models including [Detectron2](https://github.com/facebookresearch/detectron2) and [YOLOX](https://github.com/Megvii-BaseDetection/YOLOX).
 
+> [!NOTE]  
+> By default, `unstructured_inference` downloads models from [HuggingFace](https://huggingface.co/). If you would like to use models from [ModelScope](https://modelscope.cn/), set the environment variable `UNSTRUCTURED_USE_MODELSCOPE=true` before initializing the engine.
+
 ### Using a non-default model
 
 When doing inference, an alternate model can be used by passing the model object to the ingestion method via the `model` parameter. The `get_model` function can be used to construct one of our out-of-the-box models from a keyword, e.g.:

--- a/unstructured_inference/models/tables.py
+++ b/unstructured_inference/models/tables.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Union
 
+import os
 import cv2
 import numpy as np
 import torch
@@ -139,7 +140,12 @@ def load_agent():
 
     if not hasattr(tables_agent, "model"):
         logger.info("Loading the Table agent ...")
-        tables_agent.initialize("microsoft/table-transformer-structure-recognition")
+        if os.environ.get("UNSTRUCTURED_USE_MODELSCOPE", "false") == "true":
+            from modelscope import snapshot_download
+            model_dir = snapshot_download("AI-ModelScope/table-transformer-structure-recognition-v1.1-all")
+            tables_agent.initialize(model_dir)
+        else:
+            tables_agent.initialize("microsoft/table-transformer-structure-recognition")
 
     return
 

--- a/unstructured_inference/utils.py
+++ b/unstructured_inference/utils.py
@@ -112,4 +112,12 @@ def download_if_needed_and_get_local_path(path_or_repo: str, filename: str, **kw
     if os.path.exists(full_path):
         return full_path
     else:
-        return hf_hub_download(path_or_repo, filename, **kwargs)
+        if os.environ.get("UNSTRUCTURED_USE_MODELSCOPE", "false") == "true":
+            from modelscope import snapshot_download
+            path_or_repo = path_or_repo.replace(
+                "unstructuredio/", "AI-ModelScope/")
+            model_dir = snapshot_download(
+                path_or_repo, allow_patterns=filename)
+            return os.path.join(model_dir, filename)
+        else:
+            return hf_hub_download(path_or_repo, filename, **kwargs)


### PR DESCRIPTION
I am a developer from [ModelScope](https://modelscope.cn/), the largest open-source model community in China. This library is exceptional, particularly in the realm of RAG, aiding individuals in document parsing. I have introduced a new feature that allows automatically downloading models from ModelScope by simply setting an environment variable `UNSTRUCTURED_USE_MODELSCOPE=true`. This is crucial for developers in China and other countries, enabling them to focus on utilizing the tool. Thank you!