### PR TITLE
include pdfminer in base.in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.5
+
+* fix: remove `pdfplumber` but include `pdfminer-six==20240706` to update `pdfminer` 
+
 ## 0.8.4
 
 * feat: add `text_as_html` and `table_as_cells` to `LayoutElements` class as new attributes

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -13,4 +13,5 @@ transformers>=4.25.1
 rapidfuzz
 pandas
 scipy
-pdfplumber
+pypdfium2
+pdfminer-six==20240706

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -27,7 +27,7 @@ filelock==3.16.1
     #   transformers
 flatbuffers==24.12.23
     # via onnxruntime
-fonttools==4.55.3
+fonttools==4.55.4
     # via matplotlib
 fsspec==2024.12.0
     # via
@@ -83,14 +83,11 @@ packaging==24.2
     #   transformers
 pandas==2.2.3
     # via -r requirements/base.in
-pdfminer-six==20231228
-    # via pdfplumber
-pdfplumber==0.11.5
+pdfminer-six==20240706
     # via -r requirements/base.in
 pillow==11.1.0
     # via
     #   matplotlib
-    #   pdfplumber
     #   torchvision
 protobuf==5.29.3
     # via
@@ -101,7 +98,7 @@ pycparser==2.22
 pyparsing==3.2.1
     # via matplotlib
 pypdfium2==4.30.1
-    # via pdfplumber
+    # via -r requirements/base.in
 python-dateutil==2.9.0.post0
     # via
     #   matplotlib
@@ -135,7 +132,7 @@ sympy==1.13.1
     # via
     #   onnxruntime
     #   torch
-timm==1.0.13
+timm==1.0.14
     # via -r requirements/base.in
 tokenizers==0.21.0
     # via transformers
@@ -150,7 +147,7 @@ tqdm==4.67.1
     # via
     #   huggingface-hub
     #   transformers
-transformers==4.48.0
+transformers==4.48.1
     # via -r requirements/base.in
 typing-extensions==4.12.2
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -80,7 +80,7 @@ executing==2.1.0
     # via stack-data
 fastjsonschema==2.21.1
     # via nbformat
-fonttools==4.55.3
+fonttools==4.55.4
     # via
     #   -c requirements/base.txt
     #   matplotlib
@@ -106,7 +106,7 @@ idna==3.10
     #   httpx
     #   jsonschema
     #   requests
-importlib-metadata==8.5.0
+importlib-metadata==8.6.1
     # via
     #   build
     #   jupyter-client
@@ -273,7 +273,7 @@ platformdirs==4.3.6
     #   jupyter-core
 prometheus-client==0.21.1
     # via jupyter-server
-prompt-toolkit==3.0.48
+prompt-toolkit==3.0.50
     # via
     #   ipython
     #   jupyter-console

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.8.4"  # pragma: no cover
+__version__ = "0.8.5"  # pragma: no cover


### PR DESCRIPTION
when removing layoutparser package, there are some packages that installed as a dependency by layoutparser also removed.

This PR is to bring back the necessary packages still required by other scripts to pass CI. Previously, included pdfplumber to cover those deps. however, pdfminer version is bounded by pdfplumber in `unstructured`. so instead, explicitly bump the pdfminer version here