### PR TITLE
feat: make PageLayout.elements a cached property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 0.8.8-dev0
+## 0.8.8-dev1
 
 * fix: pdfminer-six dependencies
+* feat: `PageLayout.elements` is now a `cached_property` to reduce unecessary memory and cpu costs
 
 ## 0.8.7
 

--- a/test_unstructured_inference/inference/test_layout.py
+++ b/test_unstructured_inference/inference/test_layout.py
@@ -116,7 +116,7 @@ def test_get_page_elements(monkeypatch, mock_final_layout):
     )
     elements = page.get_elements_with_detection_model(inplace=False)
     page.get_elements_with_detection_model(inplace=True)
-    assert elements == page.elements
+    assert elements == page.elements_array
 
 
 class MockPool:

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.8.8-dev0"  # pragma: no cover
+__version__ = "0.8.8-dev1"  # pragma: no cover

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -163,12 +163,14 @@ class PageLayout:
     def elements(self) -> Collection[LayoutElement]:
         """return a list of layout elements from the array data structure; intended for backward
         compatibility"""
+        if self.elements_array is None:
+            return []
         return self.elements_array.as_list()
 
     def get_elements_using_image_extraction(
         self,
         inplace=True,
-    ) -> Optional[LayoutElements]:
+    ) -> Optional[list[LayoutElement]]:
         """Uses end-to-end text element extraction model to extract the elements on the page."""
         if self.element_extraction_model is None:
             raise ValueError(
@@ -184,7 +186,7 @@ class PageLayout:
     def get_elements_with_detection_model(
         self,
         inplace: bool = True,
-    ) -> Optional[List[LayoutElement]]:
+    ) -> Optional[LayoutElements]:
         """Uses specified model to detect the elements on the page."""
         if self.detection_model is None:
             model = get_model()


### PR DESCRIPTION
- default `PageLayout.get_elements_with_detection_model` now returns `LayoutElements`
- `PageLayout.elements` is a cached property computed from `elements_array` property to save memory and cpu costs