### PR TITLE
unpin numpy and raise min for onnx higher to be compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.10
+
+* feat: unpin `numpy` and bump minimum for `onnxruntime` to be compatible with `numpy>=2`
+
 ## 0.8.9
 
 * chore: unpin `pdfminer-six` version

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,10 +1,10 @@
 -c constraints.in
 python-multipart
 huggingface-hub
-numpy<2
+numpy
 opencv-python!=4.7.0.68
 onnx
-onnxruntime>=1.17.0
+onnxruntime>=1.18.0
 matplotlib
 torch
 timm

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -29,11 +29,11 @@ flatbuffers==25.2.10
     # via onnxruntime
 fonttools==4.56.0
     # via matplotlib
-fsspec==2025.2.0
+fsspec==2025.3.0
     # via
     #   huggingface-hub
     #   torch
-huggingface-hub==0.29.2
+huggingface-hub==0.29.3
     # via
     #   -r requirements/base.in
     #   timm
@@ -57,7 +57,7 @@ mpmath==1.3.0
     # via sympy
 networkx==3.2.1
     # via torch
-numpy==1.26.4
+numpy==2.0.2
     # via
     #   -r requirements/base.in
     #   contourpy
@@ -134,7 +134,7 @@ sympy==1.13.1
     #   torch
 timm==1.0.15
     # via -r requirements/base.in
-tokenizers==0.21.0
+tokenizers==0.21.1
     # via transformers
 torch==2.6.0
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -21,7 +21,7 @@ asttokens==3.0.0
     # via stack-data
 async-lru==2.0.4
     # via jupyterlab
-attrs==25.1.0
+attrs==25.3.0
     # via
     #   jsonschema
     #   referencing
@@ -236,7 +236,7 @@ notebook-shim==0.2.4
     # via
     #   jupyterlab
     #   notebook
-numpy==1.26.4
+numpy==2.0.2
     # via
     #   -c requirements/base.txt
     #   contourpy
@@ -309,14 +309,14 @@ python-dateutil==2.9.0.post0
     #   arrow
     #   jupyter-client
     #   matplotlib
-python-json-logger==3.2.1
+python-json-logger==3.3.0
     # via jupyter-events
 pyyaml==6.0.2
     # via
     #   -c requirements/base.txt
     #   -c requirements/test.txt
     #   jupyter-events
-pyzmq==26.2.1
+pyzmq==26.3.0
     # via
     #   ipykernel
     #   jupyter-client

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -40,7 +40,7 @@ flake8==7.1.2
     #   flake8-docstrings
 flake8-docstrings==1.7.0
     # via -r requirements/test.in
-fsspec==2025.2.0
+fsspec==2025.3.0
     # via
     #   -c requirements/base.txt
     #   huggingface-hub
@@ -50,7 +50,7 @@ httpcore==1.0.7
     # via httpx
 httpx==0.28.1
     # via -r requirements/test.in
-huggingface-hub==0.29.2
+huggingface-hub==0.29.3
     # via
     #   -c requirements/base.txt
     #   -r requirements/test.in
@@ -110,7 +110,7 @@ requests==2.32.3
     # via
     #   -c requirements/base.txt
     #   huggingface-hub
-ruff==0.9.9
+ruff==0.10.0
     # via -r requirements/test.in
 sniffio==1.3.1
     # via anyio

--- a/test_unstructured_inference/test_elements.py
+++ b/test_unstructured_inference/test_elements.py
@@ -47,7 +47,7 @@ def test_layoutelements():
             [0.6, 0.6, 0.65, 0.65],  # One little table nested inside all the others
             [0.5, 0.5, 0.7, 0.7],  # One nested table
             [0, 0, 1, 1],  # Big table
-            [0.01, 0.01, 1.01, 1.01],
+            [0.01, 0.01, 0.09, 0.09],
             [0.02, 0.02, 1.02, 1.02],
             [0.03, 0.03, 1.03, 1.03],
             [0.04, 0.04, 1.04, 1.04],

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.8.9"  # pragma: no cover
+__version__ = "0.8.10"  # pragma: no cover

--- a/unstructured_inference/models/base.py
+++ b/unstructured_inference/models/base.py
@@ -24,8 +24,8 @@ def get_default_model_mappings() -> Tuple[
 ]:
     """default model mappings for models that are in `unstructured_inference` repo"""
     return {
-        **{name: UnstructuredDetectronONNXModel for name in DETECTRON2_ONNX_MODEL_TYPES},
-        **{name: UnstructuredYoloXModel for name in YOLOX_MODEL_TYPES},
+        **dict.fromkeys(DETECTRON2_ONNX_MODEL_TYPES, UnstructuredDetectronONNXModel),
+        **dict.fromkeys(YOLOX_MODEL_TYPES, UnstructuredYoloXModel),
     }, {**DETECTRON2_ONNX_MODEL_TYPES, **YOLOX_MODEL_TYPES}
 
 
@@ -38,7 +38,7 @@ def register_new_model(model_config: dict, model_class: UnstructuredModel):
     Those maps are updated with the with the new model class information.
     """
     model_config_map.update(model_config)
-    model_class_map.update({name: model_class for name in model_config})
+    model_class_map.update(dict.fromkeys(model_config, model_class))
 
 
 def get_model(model_name: Optional[str] = None) -> UnstructuredModel:


### PR DESCRIPTION
This PR allows the library to be compatible with `numpy>=2`.