### PR TITLE
Fix/feature extractor parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.3
+
+* setting longest_edge=1333 to the table image processor
+
 ## 1.0.2
 
 * adding parameter to table image preprocessor related to the image size

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.2"  # pragma: no cover
+__version__ = "1.0.3"  # pragma: no cover

--- a/unstructured_inference/models/tables.py
+++ b/unstructured_inference/models/tables.py
@@ -65,6 +65,7 @@ class UnstructuredTableTransformerModel(UnstructuredModel):
         # value not set in the configuration and needed for newer models
         # https://huggingface.co/microsoft/table-transformer-structure-recognition-v1.1-all/discussions/1
         self.feature_extractor.size["shortest_edge"] = 800
+        self.feature_extractor.size["longest_edge"] = 1333
 
         try:
             logger.info("Loading the table structure model ...")


### PR DESCRIPTION
There is a regression using the default longest_edge parameter of the table image processor. In this PR, the value is set to longest_edge=1333, which shows no regression. https://github.com/Unstructured-IO/core-product/actions/runs/15167747926/job/42649970680