### PR TITLE
feat: use thread lock to prevent racing condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.5
+
+* feat: add thread lock to prevent racing condition when instantiating singletons
+
 ## 1.0.4
 
 * feat: use singleton instead of `global` to store shared variables

--- a/test_unstructured_inference/models/test_tables.py
+++ b/test_unstructured_inference/models/test_tables.py
@@ -1907,6 +1907,7 @@ def test_subcells_filtering_when_overlapping_spanning_cells(
 
 def test_model_init_is_thread_safe():
     threads = []
+    tables.tables_agent.model = None
     for i in range(5):
         thread = threading.Thread(target=tables.load_agent)
         threads.append(thread)
@@ -1914,3 +1915,5 @@ def test_model_init_is_thread_safe():
 
     for thread in threads:
         thread.join()
+
+    assert tables.tables_agent.model is not None

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.4"  # pragma: no cover
+__version__ = "1.0.5"  # pragma: no cover

--- a/unstructured_inference/models/base.py
+++ b/unstructured_inference/models/base.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import threading
 from typing import Dict, Optional, Tuple, Type
 
 from unstructured_inference.models.detectron2onnx import (
@@ -18,12 +19,15 @@ DEFAULT_MODEL = "yolox"
 
 class Models(object):
     _instance = None
+    _lock = threading.Lock()
 
     def __new__(cls):
         """return an instance if one already exists otherwise create an instance"""
         if cls._instance is None:
-            cls._instance = super(Models, cls).__new__(cls)
-            cls.models: Dict[str, UnstructuredModel] = {}
+            with cls._lock:
+                if cls._instance is None:
+                    cls._instance = super(Models, cls).__new__(cls)
+                    cls.models: Dict[str, UnstructuredModel] = {}
         return cls._instance
 
     def __contains__(self, key):

--- a/unstructured_inference/models/tables.py
+++ b/unstructured_inference/models/tables.py
@@ -1,5 +1,6 @@
 # https://github.com/microsoft/table-transformer/blob/main/src/inference.py
 # https://github.com/NielsRogge/Transformers-Tutorials/blob/master/Table%20Transformer/Using_Table_Transformer_for_table_detection_and_table_structure_recognition.ipynb
+import threading
 import xml.etree.ElementTree as ET
 from collections import defaultdict
 from pathlib import Path
@@ -28,6 +29,7 @@ class UnstructuredTableTransformerModel(UnstructuredModel):
     """Unstructured model wrapper for table-transformer."""
 
     _instance = None
+    _lock = threading.Lock()
 
     def __init__(self):
         pass
@@ -36,7 +38,9 @@ class UnstructuredTableTransformerModel(UnstructuredModel):
     def instance(cls):
         """return an instance if one already exists otherwise create an instance"""
         if cls._instance is None:
-            cls._instance = cls.__new__(cls)
+            with cls._lock:
+                if cls._instance is None:
+                    cls._instance = cls.__new__(cls)
         return cls._instance
 
     def predict(

--- a/unstructured_inference/models/tables.py
+++ b/unstructured_inference/models/tables.py
@@ -33,13 +33,12 @@ class UnstructuredTableTransformerModel(UnstructuredModel):
     _instance = None
     _lock = threading.Lock()
 
-    def __new__(cls, model: str = DEFAULT_MODEL):
+    def __new__(cls):
         """return an instance if one already exists otherwise create an instance"""
         if cls._instance is None:
             with cls._lock:
                 if cls._instance is None:
                     cls._instance = super(UnstructuredTableTransformerModel, cls).__new__(cls)
-                    cls._instance.initialize(model)
         return cls._instance
 
     def predict(

--- a/unstructured_inference/models/tables.py
+++ b/unstructured_inference/models/tables.py
@@ -24,6 +24,8 @@ from unstructured_inference.utils import pad_image_with_background_color
 
 from . import table_postprocess as postprocess
 
+DEFAULT_MODEL = "microsoft/table-transformer-structure-recognition"
+
 
 class UnstructuredTableTransformerModel(UnstructuredModel):
     """Unstructured model wrapper for table-transformer."""
@@ -31,13 +33,13 @@ class UnstructuredTableTransformerModel(UnstructuredModel):
     _instance = None
     _lock = threading.Lock()
 
-    def __new__(cls):
+    def __new__(cls, model: str = DEFAULT_MODEL):
         """return an instance if one already exists otherwise create an instance"""
         if cls._instance is None:
             with cls._lock:
                 if cls._instance is None:
                     cls._instance = super(UnstructuredTableTransformerModel, cls).__new__(cls)
-                    cls._instance.initialize("microsoft/table-transformer-structure-recognition")
+                    cls._instance.initialize(model)
         return cls._instance
 
     def predict(
@@ -156,7 +158,7 @@ def load_agent():
         with tables_agent._lock:
             if not hasattr(tables_agent, "model"):
                 logger.info("Loading the Table agent ...")
-                tables_agent.initialize("microsoft/table-transformer-structure-recognition")
+                tables_agent.initialize(DEFAULT_MODEL)
 
     return
 

--- a/unstructured_inference/models/tables.py
+++ b/unstructured_inference/models/tables.py
@@ -153,9 +153,9 @@ tables_agent: UnstructuredTableTransformerModel = UnstructuredTableTransformerMo
 def load_agent():
     """Loads the Table agent."""
 
-    if not hasattr(tables_agent, "model"):
+    if getattr(tables_agent, "model", None) is None:
         with tables_agent._lock:
-            if not hasattr(tables_agent, "model"):
+            if getattr(tables_agent, "model", None) is None:
                 logger.info("Loading the Table agent ...")
                 tables_agent.initialize(DEFAULT_MODEL)
 

--- a/unstructured_inference/models/tables.py
+++ b/unstructured_inference/models/tables.py
@@ -31,16 +31,13 @@ class UnstructuredTableTransformerModel(UnstructuredModel):
     _instance = None
     _lock = threading.Lock()
 
-    def __init__(self):
-        pass
-
-    @classmethod
-    def instance(cls):
+    def __new__(cls):
         """return an instance if one already exists otherwise create an instance"""
         if cls._instance is None:
             with cls._lock:
                 if cls._instance is None:
-                    cls._instance = cls.__new__(cls)
+                    cls._instance = super(UnstructuredTableTransformerModel, cls).__new__(cls)
+                    cls._instance.initialize("microsoft/table-transformer-structure-recognition")
         return cls._instance
 
     def predict(
@@ -149,15 +146,17 @@ class UnstructuredTableTransformerModel(UnstructuredModel):
         return prediction
 
 
-tables_agent: UnstructuredTableTransformerModel = UnstructuredTableTransformerModel.instance()
+tables_agent: UnstructuredTableTransformerModel = UnstructuredTableTransformerModel()
 
 
 def load_agent():
     """Loads the Table agent."""
 
     if not hasattr(tables_agent, "model"):
-        logger.info("Loading the Table agent ...")
-        tables_agent.initialize("microsoft/table-transformer-structure-recognition")
+        with tables_agent._lock:
+            if not hasattr(tables_agent, "model"):
+                logger.info("Loading the Table agent ...")
+                tables_agent.initialize("microsoft/table-transformer-structure-recognition")
 
     return
 

--- a/unstructured_inference/models/tables.py
+++ b/unstructured_inference/models/tables.py
@@ -71,7 +71,7 @@ class UnstructuredTableTransformerModel(UnstructuredModel):
     ):
         """Loads the donut model using the specified parameters"""
         self.device = device
-        self.feature_extractor = DetrImageProcessor.from_pretrained(model)
+        self.feature_extractor = DetrImageProcessor.from_pretrained(model, device_map=self.device)
         # value not set in the configuration and needed for newer models
         # https://huggingface.co/microsoft/table-transformer-structure-recognition-v1.1-all/discussions/1
         self.feature_extractor.size["shortest_edge"] = 800


### PR DESCRIPTION
This PR puts table model initialization behind a threadlock so it is thread safe. 

## testing
Use the following script to test (after changing extension) loading model in multithreading env.

[test_threading.txt](https://github.com/user-attachments/files/20560179/test_threading.txt)
