### PR TITLE
parametrize edge config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.5-dev0
+
+* feat: parametrize edge config for `DetrImageProcessor` with env variables
+
 ## 1.0.4
 
 * feat: use singleton instead of `global` to store shared variables

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.4"  # pragma: no cover
+__version__ = "1.0.5-dev0"  # pragma: no cover

--- a/unstructured_inference/config.py
+++ b/unstructured_inference/config.py
@@ -106,5 +106,15 @@ class InferenceConfig:
         """Same as ELEMENTS_H_PADDING_COEF but the vertical extension."""
         return self._get_float("ELEMENTS_V_PADDING_COEF", 0.3)
 
+    @property
+    def IMG_PROCESSOR_LONGEST_EDGE(self) -> int:
+        """configuration for DetrImageProcessor to scale images"""
+        return self._get_int("IMG_PROCESSOR_LONGEST_EDGE", 1333)
+
+    @property
+    def IMG_PROCESSOR_SHORTEST_EDGE(self) -> int:
+        """configuration for DetrImageProcessor to scale images"""
+        return self._get_int("IMG_PROCESSOR_SHORTEST_EDGE", 800)
+
 
 inference_config = InferenceConfig()

--- a/unstructured_inference/models/tables.py
+++ b/unstructured_inference/models/tables.py
@@ -73,8 +73,8 @@ class UnstructuredTableTransformerModel(UnstructuredModel):
         self.feature_extractor = DetrImageProcessor.from_pretrained(model)
         # value not set in the configuration and needed for newer models
         # https://huggingface.co/microsoft/table-transformer-structure-recognition-v1.1-all/discussions/1
-        self.feature_extractor.size["shortest_edge"] = 800
-        self.feature_extractor.size["longest_edge"] = 1333
+        self.feature_extractor.size["shortest_edge"] = inference_config.IMG_PROCESSOR_SHORTEST_EDGE
+        self.feature_extractor.size["longest_edge"] = inference_config.IMG_PROCESSOR_LONGEST_EDGE
 
         try:
             logger.info("Loading the table structure model ...")


### PR DESCRIPTION
This PR parametrizes the edge config for `DetrImageProcessor` model used for table transformer.