### PR TITLE
feat: add element slicing support

### DIFF
--- a/test_unstructured_inference/test_elements.py
+++ b/test_unstructured_inference/test_elements.py
@@ -472,3 +472,27 @@ def test_layoutelements_concatenate():
     assert joint.sources.tolist() == ["yolox", "yolox", "ocr", "ocr"]
     assert joint.element_class_ids.tolist() == [0, 1, 1, 2]
     assert joint.element_class_id_map == {0: "type0", 1: "type1", 2: "type2"}
+
+
+def test_textregions_support_numpy_slicing():
+    trs = TextRegions(
+        element_coords=np.array(
+            [
+                [0.0, 0.0, 1.0, 1.0],
+                [1.0, 0.0, 1.5, 1.0],
+                [2.0, 0.0, 2.5, 1.0],
+                [3.0, 0.0, 4.0, 1.0],
+                [4.0, 0.0, 5.0, 1.0],
+            ]
+        ),
+        texts=np.array(["0", "1", "2", "3", "4"]),
+        sources=np.array(["foo", "foo", "foo", "foo", "foo"], dtype="<U3"),
+        source=np.str_("foo"),
+    )
+    np.testing.assert_equal(trs[1:4].texts, np.array(["1", "2", "3"]))
+    np.testing.assert_equal(trs[0::2].texts, np.array(["0", "2", "4"]))
+    np.testing.assert_equal(trs[[1, 2, 4]].texts, np.array(["1", "2", "4"]))
+    np.testing.assert_equal(trs[np.array([1, 2, 4])].texts, np.array(["1", "2", "4"]))
+    np.testing.assert_equal(
+        trs[np.array([True, False, False, True, False])].texts, np.array(["0", "3"])
+    )

--- a/test_unstructured_inference/test_elements.py
+++ b/test_unstructured_inference/test_elements.py
@@ -474,25 +474,47 @@ def test_layoutelements_concatenate():
     assert joint.element_class_id_map == {0: "type0", 1: "type1", 2: "type2"}
 
 
-def test_textregions_support_numpy_slicing():
-    trs = TextRegions(
-        element_coords=np.array(
-            [
-                [0.0, 0.0, 1.0, 1.0],
-                [1.0, 0.0, 1.5, 1.0],
-                [2.0, 0.0, 2.5, 1.0],
-                [3.0, 0.0, 4.0, 1.0],
-                [4.0, 0.0, 5.0, 1.0],
-            ]
+@pytest.mark.parametrize(
+    "test_elements",
+    [
+        TextRegions(
+            element_coords=np.array(
+                [
+                    [0.0, 0.0, 1.0, 1.0],
+                    [1.0, 0.0, 1.5, 1.0],
+                    [2.0, 0.0, 2.5, 1.0],
+                    [3.0, 0.0, 4.0, 1.0],
+                    [4.0, 0.0, 5.0, 1.0],
+                ]
+            ),
+            texts=np.array(["0", "1", "2", "3", "4"]),
+            sources=np.array(["foo", "foo", "foo", "foo", "foo"], dtype="<U3"),
+            source=np.str_("foo"),
         ),
-        texts=np.array(["0", "1", "2", "3", "4"]),
-        sources=np.array(["foo", "foo", "foo", "foo", "foo"], dtype="<U3"),
-        source=np.str_("foo"),
-    )
-    np.testing.assert_equal(trs[1:4].texts, np.array(["1", "2", "3"]))
-    np.testing.assert_equal(trs[0::2].texts, np.array(["0", "2", "4"]))
-    np.testing.assert_equal(trs[[1, 2, 4]].texts, np.array(["1", "2", "4"]))
-    np.testing.assert_equal(trs[np.array([1, 2, 4])].texts, np.array(["1", "2", "4"]))
+        LayoutElements(
+            element_coords=np.array(
+                [
+                    [0.0, 0.0, 1.0, 1.0],
+                    [1.0, 0.0, 1.5, 1.0],
+                    [2.0, 0.0, 2.5, 1.0],
+                    [3.0, 0.0, 4.0, 1.0],
+                    [4.0, 0.0, 5.0, 1.0],
+                ]
+            ),
+            texts=np.array(["0", "1", "2", "3", "4"]),
+            sources=np.array(["foo", "foo", "foo", "foo", "foo"], dtype="<U3"),
+            source=np.str_("foo"),
+            element_probs=np.array([0.0, 0.1, 0.2, 0.3, 0.4]),
+        ),
+    ],
+)
+def test_textregions_support_numpy_slicing(test_elements):
+    np.testing.assert_equal(test_elements[1:4].texts, np.array(["1", "2", "3"]))
+    np.testing.assert_equal(test_elements[0::2].texts, np.array(["0", "2", "4"]))
+    np.testing.assert_equal(test_elements[[1, 2, 4]].texts, np.array(["1", "2", "4"]))
+    np.testing.assert_equal(test_elements[np.array([1, 2, 4])].texts, np.array(["1", "2", "4"]))
     np.testing.assert_equal(
-        trs[np.array([True, False, False, True, False])].texts, np.array(["0", "3"])
+        test_elements[np.array([True, False, False, True, False])].texts, np.array(["0", "3"])
     )
+    if isinstance(test_elements, LayoutElements):
+        np.testing.assert_almost_equal(test_elements[1:4].element_probs, np.array([0.1, 0.2, 0.3]))

--- a/unstructured_inference/inference/elements.py
+++ b/unstructured_inference/inference/elements.py
@@ -227,6 +227,9 @@ class TextRegions:
         self.element_coords = self.element_coords.astype(float)
 
     def __getitem__(self, indices) -> TextRegions:
+        return self.slice(indices)
+
+    def slice(self, indices) -> TextRegions:
         """slice text regions based on indices"""
         return TextRegions(
             element_coords=self.element_coords[indices],

--- a/unstructured_inference/inference/elements.py
+++ b/unstructured_inference/inference/elements.py
@@ -226,7 +226,7 @@ class TextRegions:
         # we convert to float so data type is more consistent (e.g., None will be np.nan)
         self.element_coords = self.element_coords.astype(float)
 
-    def slice(self, indices) -> TextRegions:
+    def __getitem__(self, indices) -> TextRegions:
         """slice text regions based on indices"""
         return TextRegions(
             element_coords=self.element_coords[indices],

--- a/unstructured_inference/inference/layoutelement.py
+++ b/unstructured_inference/inference/layoutelement.py
@@ -75,7 +75,7 @@ class LayoutElements(TextRegions):
             and np.array_equal(self.table_as_cells[mask], other.table_as_cells[mask])
         )
 
-    def slice(self, indices) -> LayoutElements:
+    def __getitem__(self, indices) -> LayoutElements:
         """slice and return only selected indices"""
         return LayoutElements(
             element_coords=self.element_coords[indices],

--- a/unstructured_inference/inference/layoutelement.py
+++ b/unstructured_inference/inference/layoutelement.py
@@ -75,7 +75,10 @@ class LayoutElements(TextRegions):
             and np.array_equal(self.table_as_cells[mask], other.table_as_cells[mask])
         )
 
-    def __getitem__(self, indices) -> LayoutElements:
+    def __getitem__(self, indices):
+        return self.slice(indices)
+
+    def slice(self, indices) -> LayoutElements:
         """slice and return only selected indices"""
         return LayoutElements(
             element_coords=self.element_coords[indices],


### PR DESCRIPTION
I noticed we had support for slicing of `LayoutElements` and `TextRegions`, but through a `slice` method rather than using an index, so I added the indexing as an alias for `slice`.