### PR TITLE
fix: Do not hardcode file extension on temp files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.7
+
+* Fix a hardcoded file extension causing confusion in the logs
+
 ## 1.0.6
 
 * Add slicing through indexing for vectorized elements

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.6"  # pragma: no cover
+__version__ = "1.0.7"  # pragma: no cover

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -368,8 +368,8 @@ def process_file_with_model(
     password: Optional[str] = None,
     **kwargs: Any,
 ) -> DocumentLayout:
-    """Processes pdf or image file with name filename into a DocumentLayout by using a model identified by
-    model_name."""
+    """Processes pdf or image file with name filename into a DocumentLayout by using
+    a model identified by model_name."""
 
     model = get_model(model_name, **kwargs)
     if isinstance(model, UnstructuredObjectDetectionModel):

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -337,12 +337,15 @@ def process_data_with_model(
     password: Optional[str] = None,
     **kwargs: Any,
 ) -> DocumentLayout:
-    """Process PDF as file-like object `data` into a `DocumentLayout`.
+    """Process PDF or image as file-like object `data` into a `DocumentLayout`.
 
     Uses the model identified by `model_name`.
     """
+    # Note: We use a temp dir, not a temp file,
+    # because the latter fails on Windows
+    # https://github.com/Unstructured-IO/unstructured-inference/pull/376
     with tempfile.TemporaryDirectory() as tmp_dir_path:
-        file_path = os.path.join(tmp_dir_path, "document.pdf")
+        file_path = os.path.join(tmp_dir_path, "document")
         with open(file_path, "wb") as f:
             f.write(data.read())
             f.flush()
@@ -365,7 +368,7 @@ def process_file_with_model(
     password: Optional[str] = None,
     **kwargs: Any,
 ) -> DocumentLayout:
-    """Processes pdf file with name filename into a DocumentLayout by using a model identified by
+    """Processes pdf or image file with name filename into a DocumentLayout by using a model identified by
     model_name."""
 
     model = get_model(model_name, **kwargs)


### PR DESCRIPTION
This is a minor fix to improve our logging. When we buffer a file like input to disk in `process_data_with_model`, we always use the name `document.pdf`. This confused me when I found this in our logs:

```
2025-06-30 17:02:01,906 unstructured_inference INFO Reading image file: /var/folders/5k/frv076q97yl0ywybmzydhbsr0000gn/T/tmpc0uq7zde/document.pdf ...
2025-06-30 17:02:01,951 unstructured_api ERROR cannot identify image file '/private/var/folders/5k/frv076q97yl0ywybmzydhbsr0000gn/T/tmpc0uq7zde/document.pdf'
```

This path can be either pdfs or images, so let's just drop the extension to save ourselves some confusion.

Also added a comment so we don't forget why it's using a temp dir, not a temp file.