### PR TITLE
Adding OD source for TableFormer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.8
+
+* Adding source for table detection from TableFormer
+
 ## 1.0.7
 
 * Fix a hardcoded file extension causing confusion in the logs

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.7"  # pragma: no cover
+__version__ = "1.0.8"  # pragma: no cover

--- a/unstructured_inference/constants.py
+++ b/unstructured_inference/constants.py
@@ -6,6 +6,7 @@ class Source(Enum):
     DETECTRON2_ONNX = "detectron2_onnx"
     DETECTRON2_LP = "detectron2_lp"
     MERGED = "merged"
+    TABLEFORMER = "tableformer"
 
 
 class ElementType:


### PR DESCRIPTION
Adding TableFormer as source: https://linear.app/unstructured/issue/ML-272/explore-merging-doclings-od-model-results-with-unst-od-model-results