### PR TITLE
fix: convert LazyDict to dict before unpacking in get_model

### DIFF
--- a/unstructured_inference/models/base.py
+++ b/unstructured_inference/models/base.py
@@ -137,7 +137,7 @@ def get_model(model_name: Optional[str] = None) -> UnstructuredModel:
 
         model: UnstructuredModel = model_class_map[model_name]()
 
-        model.initialize(**initialize_params)
+        model.initialize(**dict(initialize_params))
         models[model_name] = model
     return model
 


### PR DESCRIPTION
## Summary
Fixes Unstructured-IO/unstructured#4063.
**Root cause:** `initialize_params` from `model_config_map` is a `LazyDict` instance (used for lazy model path resolution). Python rejects `LazyDict` for `**` unpacking in function calls with `TypeError: argument after ** must be a mapping, not LazyDict`, even though `LazyDict` implements the `Mapping` protocol.
**Fix:** Convert `initialize_params` to a plain `dict` before unpacking with `model.initialize(**dict(initialize_params))`. This evaluates any lazy values and produces a standard dict that `**` unpacking accepts in all Python versions.
## Changes
- `unstructured_inference/models/base.py`: Changed `model.initialize(**initialize_params)` to `model.initialize(**dict(initialize_params))`
## Testing
- Verified fix addresses reported scenario (YOLOX model initialization with LazyDict params)
- Change is minimal and follows existing code patterns

Made with [Cursor](https://cursor.com)