### PR TITLE
fix: fix rare occasion of initialization error by converting LazyDict into dict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.6.7
+
+### Fix
+- `get_model` now materializes `LazyDict` model configs into a plain dict before
+  unpacking into `initialize(**...)`. Uses `__iter__` + `__getitem__` to avoid
+  depending on `Mapping.keys()`, which has been observed to fail at `**`
+  unpacking with "argument after ** must be a mapping, not LazyDict" in some
+  deployment environments.
+
 ## 1.6.6
 
 ### Enhancement

--- a/test_unstructured_inference/models/test_model.py
+++ b/test_unstructured_inference/models/test_model.py
@@ -182,6 +182,41 @@ def test_register_new_model():
     assert "foo" not in models.model_config_map
 
 
+def test_get_model_with_lazydict_config(monkeypatch):
+    """get_model must unpack a LazyDict config into initialize() without
+    depending on Mapping.keys() — prevents regression of
+    'argument after ** must be a mapping, not LazyDict' in prod.
+    """
+    from unstructured_inference.utils import LazyDict, LazyEvaluateInfo
+
+    monkeypatch.setattr(models, "models", {})
+
+    evaluated = []
+
+    def _fake_download(path):
+        evaluated.append(path)
+        return path
+
+    lazy_config = LazyDict(
+        model_path=LazyEvaluateInfo(_fake_download, "/tmp/weights.onnx"),
+        input_shape=(640, 640),
+    )
+
+    with (
+        mock.patch.dict(models.model_class_map, {"lazy_mock": MockModel}),
+        mock.patch.dict(models.model_config_map, {"lazy_mock": lazy_config}),
+    ):
+        model = models.get_model("lazy_mock")
+
+    assert isinstance(model, MockModel)
+    assert evaluated == ["/tmp/weights.onnx"]
+    model.initializer.assert_called_once_with(
+        model,
+        model_path="/tmp/weights.onnx",
+        input_shape=(640, 640),
+    )
+
+
 def test_raises_invalid_model():
     with pytest.raises(models.UnknownModelException):
         models.get_model("fake_model")

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.6.6"  # pragma: no cover
+__version__ = "1.6.7"  # pragma: no cover

--- a/unstructured_inference/models/base.py
+++ b/unstructured_inference/models/base.py
@@ -137,6 +137,12 @@ def get_model(model_name: Optional[str] = None) -> UnstructuredModel:
 
         model: UnstructuredModel = model_class_map[model_name]()
 
+        # Normalize to a plain dict via __iter__ + __getitem__. `**` unpacking
+        # calls `.keys()` on the mapping, which LazyDict inherits from
+        # collections.abc.Mapping — but we've seen environments where that
+        # inherited method isn't found at call time, surfacing as
+        # "argument after ** must be a mapping, not LazyDict".
+        initialize_params = {k: initialize_params[k] for k in initialize_params}
         model.initialize(**initialize_params)
         models[model_name] = model
     return model


### PR DESCRIPTION
## Summary

  Fix `"argument after ** must be a mapping, not LazyDict"` raised from `get_model()` in some production environments.

  `get_model()` was doing `model.initialize(**initialize_params)` where `initialize_params` is a `LazyDict`. `**` unpacking calls `.keys()` on
  the mapping, which `LazyDict` inherits from `collections.abc.Mapping` — but we've seen environments where that inherited method isn't resolved
   at call time, surfacing as the error above.

  The fix materializes `initialize_params` into a plain `dict` via `__iter__` + `__getitem__` (both defined directly on `LazyDict`) before the
  `**` unpack. `LazyEvaluateInfo` values are still resolved lazily via `__getitem__`, so download-on-first-use semantics are preserved.

  ## Changes

  - `unstructured_inference/models/base.py` — normalize `initialize_params` to a plain dict before `model.initialize(**...)`.
  - `test_unstructured_inference/models/test_model.py` — new regression test `test_get_model_with_lazydict_config` exercising the `LazyDict`
  path with a `LazyEvaluateInfo` value.
  - `CHANGELOG.md` + `__version__.py` — bump to `1.6.7`.