### PR TITLE
Reject oversized PDF renders before bitmap allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.6.8
+
+### Fix
+- Reject PDF pages that would render beyond the configured pixel limit before
+  allocating the page bitmap.
+
 ## 1.6.7
 
 ### Fix

--- a/test_unstructured_inference/inference/test_layout.py
+++ b/test_unstructured_inference/inference/test_layout.py
@@ -9,7 +9,7 @@ from PIL import Image
 
 import unstructured_inference.models.base as models
 from unstructured_inference.constants import IsExtracted
-from unstructured_inference.inference import elements, layout, layoutelement
+from unstructured_inference.inference import elements, layout, layoutelement, pdf_image
 from unstructured_inference.inference.elements import (
     EmbeddedTextRegion,
     ImageTextRegion,
@@ -597,6 +597,7 @@ def test_process_file_with_model_routing(monkeypatch, model_type, is_detection_m
             fixed_layouts=None,
             password=None,
             pdf_image_dpi=200,
+            pdf_render_max_pixels_per_page=None,
         )
 
 
@@ -611,6 +612,105 @@ def test_convert_pdf_to_image_no_output_folder():
     result = layout.convert_pdf_to_image(filename="sample-docs/loremipsum.pdf", dpi=72)
     assert len(result) == 1
     assert isinstance(result[0], Image.Image)
+
+
+def _install_mock_pdfium(monkeypatch, *, width=720, height=720):
+    class MockBitmap:
+        def to_pil(self):
+            return Image.new("RGB", (1, 1))
+
+        def close(self):
+            pass
+
+    class MockPage:
+        render_called = False
+
+        def get_width(self):
+            return width
+
+        def get_height(self):
+            return height
+
+        def get_rotation(self):
+            return 0
+
+        def render(self, **kwargs):
+            self.render_called = True
+            return MockBitmap()
+
+        def close(self):
+            pass
+
+    page = MockPage()
+
+    class MockPdf:
+        def __len__(self):
+            return 1
+
+        def __getitem__(self, index):
+            return page
+
+        def close(self):
+            pass
+
+    class MockPdfium:
+        @staticmethod
+        def PdfDocument(*args, **kwargs):
+            return MockPdf()
+
+    monkeypatch.setattr(pdf_image, "_get_pdfium_module", lambda: MockPdfium)
+    return page
+
+
+def test_convert_pdf_to_image_rejects_oversized_page_before_render(monkeypatch):
+    page = _install_mock_pdfium(monkeypatch)
+
+    with pytest.raises(pdf_image.PdfRenderTooLargeError, match="too many pixels"):
+        pdf_image.convert_pdf_to_image(
+            filename="mock.pdf",
+            dpi=100,
+            pdf_render_max_pixels_per_page=999_999,
+        )
+
+    assert not page.render_called
+
+
+def test_convert_pdf_to_image_allows_render_guard_to_be_disabled(monkeypatch):
+    page = _install_mock_pdfium(monkeypatch)
+
+    result = pdf_image.convert_pdf_to_image(
+        filename="mock.pdf",
+        dpi=100,
+        pdf_render_max_pixels_per_page=0,
+    )
+
+    assert page.render_called
+    assert len(result) == 1
+    assert isinstance(result[0], Image.Image)
+
+
+def test_page_hotload_preserves_render_max_pixels_per_page(monkeypatch, tmp_path):
+    image_path = tmp_path / "page_1.png"
+    Image.new("RGB", (1, 1)).save(image_path)
+    calls = []
+
+    def fake_convert_pdf_to_image(**kwargs):
+        calls.append(kwargs)
+        return [str(image_path)]
+
+    monkeypatch.setattr(layout, "convert_pdf_to_image", fake_convert_pdf_to_image)
+    page = layout.PageLayout(
+        number=1,
+        image=Image.new("RGB", (1, 1)),
+        document_filename="mock.pdf",
+        pdf_render_max_pixels_per_page=None,
+    )
+
+    image = page._get_image("mock.pdf", 1, pdf_image_dpi=123)
+
+    assert image.size == (1, 1)
+    assert calls[0]["dpi"] == 123
+    assert calls[0]["pdf_render_max_pixels_per_page"] is None
 
 
 def test_convert_pdf_to_image_output_folder_returns_images(tmp_path):

--- a/test_unstructured_inference/inference/test_layout.py
+++ b/test_unstructured_inference/inference/test_layout.py
@@ -1,7 +1,7 @@
 import os
 import os.path
 import tempfile
-from unittest.mock import mock_open, patch
+from unittest.mock import MagicMock, mock_open, patch
 
 import numpy as np
 import pytest
@@ -615,50 +615,17 @@ def test_convert_pdf_to_image_no_output_folder():
 
 
 def _install_mock_pdfium(monkeypatch, *, width=720, height=720):
-    class MockBitmap:
-        def to_pil(self):
-            return Image.new("RGB", (1, 1))
-
-        def close(self):
-            pass
-
-    class MockPage:
-        render_called = False
-
-        def get_width(self):
-            return width
-
-        def get_height(self):
-            return height
-
-        def get_rotation(self):
-            return 0
-
-        def render(self, **kwargs):
-            self.render_called = True
-            return MockBitmap()
-
-        def close(self):
-            pass
-
-    page = MockPage()
-
-    class MockPdf:
-        def __len__(self):
-            return 1
-
-        def __getitem__(self, index):
-            return page
-
-        def close(self):
-            pass
-
-    class MockPdfium:
-        @staticmethod
-        def PdfDocument(*args, **kwargs):
-            return MockPdf()
-
-    monkeypatch.setattr(pdf_image, "_get_pdfium_module", lambda: MockPdfium)
+    page = MagicMock()
+    page.get_width.return_value = width
+    page.get_height.return_value = height
+    page.get_rotation.return_value = 0
+    page.render.return_value.to_pil.return_value = Image.new("RGB", (1, 1))
+    pdf = MagicMock()
+    pdf.__len__.return_value = 1
+    pdf.__getitem__.return_value = page
+    pdfium = MagicMock()
+    pdfium.PdfDocument.return_value = pdf
+    monkeypatch.setattr(pdf_image, "_get_pdfium_module", lambda: pdfium)
     return page
 
 
@@ -672,7 +639,7 @@ def test_convert_pdf_to_image_rejects_oversized_page_before_render(monkeypatch):
             pdf_render_max_pixels_per_page=999_999,
         )
 
-    assert not page.render_called
+    page.render.assert_not_called()
 
 
 def test_convert_pdf_to_image_allows_render_guard_to_be_disabled(monkeypatch):
@@ -684,7 +651,7 @@ def test_convert_pdf_to_image_allows_render_guard_to_be_disabled(monkeypatch):
         pdf_render_max_pixels_per_page=0,
     )
 
-    assert page.render_called
+    page.render.assert_called_once()
     assert len(result) == 1
     assert isinstance(result[0], Image.Image)
 

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.6.7"  # pragma: no cover
+__version__ = "1.6.8"  # pragma: no cover

--- a/unstructured_inference/config.py
+++ b/unstructured_inference/config.py
@@ -116,5 +116,14 @@ class InferenceConfig:
         """configuration for DetrImageProcessor to scale images"""
         return self._get_int("IMG_PROCESSOR_SHORTEST_EDGE", 800)
 
+    @property
+    def PDF_RENDER_MAX_PIXELS_PER_PAGE(self) -> int:
+        """maximum number of pixels (width * height) a single PDF page may render to
+
+        Pages whose rendered bitmap would exceed this value are rejected before allocation.
+        Set to 0 to disable the guard.
+        """
+        return self._get_int("PDF_RENDER_MAX_PIXELS_PER_PAGE", 1_000_000_000)
+
 
 inference_config = InferenceConfig()

--- a/unstructured_inference/constants.py
+++ b/unstructured_inference/constants.py
@@ -48,3 +48,5 @@ FULL_PAGE_REGION_THRESHOLD = 0.99
 
 # this field is defined by pytesseract/unstructured.pytesseract
 TESSERACT_TEXT_HEIGHT = "height"
+
+PDF_POINTS_PER_INCH = 72

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -55,6 +55,7 @@ class DocumentLayout:
         filename: str,
         fixed_layouts: Optional[List[Optional[List[TextRegion]]]] = None,
         pdf_image_dpi: int = 200,
+        pdf_render_max_pixels_per_page: Optional[int] = None,
         password: Optional[str] = None,
         **kwargs,
     ) -> DocumentLayout:
@@ -68,6 +69,7 @@ class DocumentLayout:
                 output_folder=temp_dir,
                 path_only=True,
                 password=password,
+                pdf_render_max_pixels_per_page=pdf_render_max_pixels_per_page,
             )
             image_paths = cast(List[str], _image_paths)
             number_of_pages = len(image_paths)
@@ -83,6 +85,7 @@ class DocumentLayout:
                         number=i + 1,
                         document_filename=filename,
                         fixed_layout=fixed_layout,
+                        pdf_render_max_pixels_per_page=pdf_render_max_pixels_per_page,
                         **kwargs,
                     )
                     pages.append(page)
@@ -139,6 +142,7 @@ class PageLayout:
         document_filename: Optional[Union[str, PurePath]] = None,
         detection_model: Optional[UnstructuredObjectDetectionModel] = None,
         element_extraction_model: Optional[UnstructuredElementExtractionModel] = None,
+        pdf_render_max_pixels_per_page: Optional[int] = None,
         password: Optional[str] = None,
     ):
         if detection_model is not None and element_extraction_model is not None:
@@ -153,6 +157,7 @@ class PageLayout:
         self.number = number
         self.detection_model = detection_model
         self.element_extraction_model = element_extraction_model
+        self.pdf_render_max_pixels_per_page = pdf_render_max_pixels_per_page
         self.elements_array: LayoutElements | None = None
         self.password = password
         # NOTE(alan): Dropped LocationlessLayoutElement that was created for chipper - chipper has
@@ -287,6 +292,7 @@ class PageLayout:
                 dpi=pdf_image_dpi,
                 output_folder=temp_dir,
                 path_only=True,
+                pdf_render_max_pixels_per_page=self.pdf_render_max_pixels_per_page,
             )
             image_paths = cast(List[str], _image_paths)
             if page_number > len(image_paths):
@@ -307,6 +313,7 @@ class PageLayout:
         detection_model: Optional[UnstructuredObjectDetectionModel] = None,
         element_extraction_model: Optional[UnstructuredElementExtractionModel] = None,
         fixed_layout: Optional[List[TextRegion]] = None,
+        pdf_render_max_pixels_per_page: Optional[int] = None,
     ):
         """Creates a PageLayout from an already-loaded PIL Image."""
 
@@ -315,6 +322,7 @@ class PageLayout:
             image=image,
             detection_model=detection_model,
             element_extraction_model=element_extraction_model,
+            pdf_render_max_pixels_per_page=pdf_render_max_pixels_per_page,
         )
         # FIXME (yao): refactor the other methods so they all return elements like the third route
         if page.element_extraction_model is not None:
@@ -373,6 +381,7 @@ def process_file_with_model(
     is_image: bool = False,
     fixed_layouts: Optional[List[Optional[List[TextRegion]]]] = None,
     pdf_image_dpi: int = 200,
+    pdf_render_max_pixels_per_page: Optional[int] = None,
     password: Optional[str] = None,
     **kwargs: Any,
 ) -> DocumentLayout:
@@ -402,6 +411,7 @@ def process_file_with_model(
             element_extraction_model=element_extraction_model,
             fixed_layouts=fixed_layouts,
             pdf_image_dpi=pdf_image_dpi,
+            pdf_render_max_pixels_per_page=pdf_render_max_pixels_per_page,
             password=password,
             **kwargs,
         )

--- a/unstructured_inference/inference/pdf_image.py
+++ b/unstructured_inference/inference/pdf_image.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 import os
 from functools import lru_cache
 from pathlib import Path, PurePath
@@ -9,7 +10,30 @@ from typing import BinaryIO, Optional, Union
 from PIL import Image
 from PIL.PngImagePlugin import PngInfo
 
+from unstructured_inference.config import inference_config
+from unstructured_inference.constants import PDF_POINTS_PER_INCH
+
 _pdfium_lock = Lock()
+
+
+class PdfRenderTooLargeError(ValueError):
+    pass
+
+
+def _check_pdf_render_max_pixels(page, page_number: int, scale: float, maximum: int) -> None:
+    if maximum <= 0:
+        return
+
+    rendered_width = math.ceil(page.get_width() * scale)
+    rendered_height = math.ceil(page.get_height() * scale)
+    rendered_pixels = rendered_width * rendered_height
+
+    if rendered_pixels > maximum:
+        raise PdfRenderTooLargeError(
+            "PDF page would render to too many pixels for safe processing: "
+            f"page={page_number}, pixels={rendered_pixels}, maximum={maximum}. "
+            "Try splitting the PDF, reducing the page dimensions, or using a lower render DPI.",
+        )
 
 
 @lru_cache(maxsize=1)
@@ -28,6 +52,7 @@ def convert_pdf_to_image(
     first_page: Optional[int] = None,
     last_page: Optional[int] = None,
     password: Optional[str] = None,
+    pdf_render_max_pixels_per_page: Optional[int] = None,
 ) -> Union[list[Image.Image], list[str]]:
     """Render PDF pages to PIL images or saved PNGs using pypdfium2.
 
@@ -42,7 +67,9 @@ def convert_pdf_to_image(
         assert Path(output_folder).exists()
         assert Path(output_folder).is_dir()
 
-    scale = dpi / 72.0
+    scale = dpi / PDF_POINTS_PER_INCH
+    if pdf_render_max_pixels_per_page is None:
+        pdf_render_max_pixels_per_page = inference_config.PDF_RENDER_MAX_PIXELS_PER_PAGE
     pdfium = _get_pdfium_module()
 
     with _pdfium_lock:
@@ -62,6 +89,12 @@ def convert_pdf_to_image(
             with _pdfium_lock:
                 page = pdf[i]
                 try:
+                    _check_pdf_render_max_pixels(
+                        page=page,
+                        page_number=page_num,
+                        scale=scale,
+                        maximum=pdf_render_max_pixels_per_page,
+                    )
                     bitmap = page.render(
                         scale=scale,
                         no_smoothtext=False,


### PR DESCRIPTION
## Summary
- add a configurable per-page PDF render pixel limit
- reject pages before `page.render()` would allocate an oversized bitmap
- preserve the render limit for later page image hotloads

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new failure mode during PDF rendering (`PdfRenderTooLargeError`) and threads a new limit parameter through core PDF→image and layout entrypoints, which could affect callers relying on rendering very large pages.
> 
> **Overview**
> Adds a configurable per-page PDF render guard (`PDF_RENDER_MAX_PIXELS_PER_PAGE`) and enforces it in `convert_pdf_to_image` by estimating rendered pixel count *before* calling `page.render()`, raising `PdfRenderTooLargeError` when exceeded (0 disables the guard).
> 
> Threads `pdf_render_max_pixels_per_page` through `DocumentLayout.from_file`, `PageLayout` hotload (`_get_image`), and `process_file_with_model` so the same limit is applied consistently, and bumps version to `1.6.8` with new targeted tests validating rejection and limit propagation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efd5375d6409cd5bacdb5839913bc9d955e236be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->