### PR TITLE
Prepare 1.6.10 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.6.10
+
+### Enhancement
+- Add Python 3.13 support.
+
 ## 1.6.9
 
 ### Enhancement

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.6.9"  # pragma: no cover
+__version__ = "1.6.10"  # pragma: no cover


### PR DESCRIPTION
## Summary

- Add a `1.6.10` changelog entry for Python 3.13 support
- Bump `unstructured_inference.__version__` to `1.6.10`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release metadata update only: bumps the library version and adds a changelog entry; no runtime logic changes.
> 
> **Overview**
> Prepares the `1.6.10` release by adding a `1.6.10` entry to `CHANGELOG.md` noting **Python 3.13 support**.
> 
> Bumps `unstructured_inference.__version__` from `1.6.9` to `1.6.10`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fca34978ea40ba159476356ad438ab22348bff1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->