### PR TITLE
fix: render rotated PDF pages consistently with extracted text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.6.12
+
+### Fixes
+- **Render rotated PDF pages consistently with extracted text**: `convert_pdf_to_image` no longer re-applies the page `/Rotate` on top of pypdfium2's render (which already produces the display frame), so the rendered image stays in the same coordinate frame as pdfminer's extracted text. For pages with a non-zero `/Rotate`, the dominant text orientation is detected and, when a single 90-degree orientation clearly dominates (configurable via `PDF_ROTATION_DOMINANT_ANGLE_THRESHOLD`), the image is rotated so its text is upright. The applied correction is exposed as `pdf_rotation_correction` in the page image metadata so downstream consumers can keep extracted coordinates aligned.
+
 ## 1.6.11
 
 ### Enhancement

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,8 @@ dependencies = [
     "pandas>=1.5.0",
     "scipy>=1.17.0",
     "pypdfium2>=5.0.0",
+    # Used to read per-character matrices for PDF page text-orientation correction
+    "pdfminer.six>=20231228",
 ]
 
 [project.urls]

--- a/test_unstructured_inference/inference/test_layout.py
+++ b/test_unstructured_inference/inference/test_layout.py
@@ -273,6 +273,7 @@ def test_from_image_file(monkeypatch, mock_final_layout, filetype, element_extra
         "width": image.width,
         "height": image.height,
         "pdf_rotation": 0,
+        "pdf_rotation_correction": 0,
     }
 
     doc = layout.DocumentLayout.from_image_file(
@@ -301,6 +302,7 @@ def test_from_file(monkeypatch, mock_final_layout):
             "width": image.width,
             "height": image.height,
             "pdf_rotation": 0,
+            "pdf_rotation_correction": 0,
         }
 
         with patch.object(

--- a/test_unstructured_inference/inference/test_layout_rotation.py
+++ b/test_unstructured_inference/inference/test_layout_rotation.py
@@ -10,9 +10,12 @@ def test_convert_pdf_to_image_applies_rotation():
     result = pdf_image.convert_pdf_to_image(filename="sample-docs/rotated-page-90.pdf", dpi=72)
     assert len(result) == 1
     img = result[0]
-    # The PDF has /Rotate=90 on a landscape page (width > height in PDF units).
-    # Without rotation fix the rendered image would be landscape; with the fix it's portrait.
+    # pypdfium2 renders this /Rotate=90 page in its display frame (landscape, text sideways);
+    # the text-orientation correction then rotates it back upright (portrait), and records the
+    # angle so the pdfminer coordinates can be rotated to match downstream.
     assert img.height > img.width, f"Expected portrait after rotation, got {img.size}"
+    assert img.info.get("pdf_rotation") == 90
+    assert img.info.get("pdf_rotation_correction") == 90
 
     # Fixture contract: rotated-page-90.pdf has visible dark text in the upper half when upright.
     # Use relative dark-pixel counts to reduce sensitivity to minor renderer differences.
@@ -26,3 +29,25 @@ def test_convert_pdf_to_image_applies_rotation():
         "Expected substantially more dark pixels in upper half for upright orientation; "
         f"got top={top_dark_pixels}, bottom={bottom_dark_pixels}"
     )
+
+
+def test_convert_pdf_to_image_no_correction_for_unrotated_page():
+    """Pages without /Rotate are rendered as-is with a zero correction."""
+    result = pdf_image.convert_pdf_to_image(filename="sample-docs/loremipsum.pdf", dpi=72)
+    img = result[0]
+    assert img.info.get("pdf_rotation") == 0
+    assert img.info.get("pdf_rotation_correction") == 0
+
+
+def test_convert_pdf_to_image_skips_correction_below_threshold(monkeypatch):
+    """A high dominant-angle threshold leaves the page in its native display frame.
+
+    This guards against re-orienting pages without a clear dominant text direction: with an
+    unreachable threshold no correction is applied even though /Rotate is non-zero.
+    """
+    monkeypatch.setenv("PDF_ROTATION_DOMINANT_ANGLE_THRESHOLD", "1.1")
+    img = pdf_image.convert_pdf_to_image(filename="sample-docs/rotated-page-90.pdf", dpi=72)[0]
+    assert img.info.get("pdf_rotation") == 90
+    assert img.info.get("pdf_rotation_correction") == 0
+    # native display frame for this page is landscape (sideways), i.e. no correction applied
+    assert img.width > img.height, f"Expected uncorrected landscape frame, got {img.size}"

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.6.11"  # pragma: no cover
+__version__ = "1.6.12"  # pragma: no cover

--- a/unstructured_inference/config.py
+++ b/unstructured_inference/config.py
@@ -117,6 +117,16 @@ class InferenceConfig:
         return self._get_int("IMG_PROCESSOR_SHORTEST_EDGE", 800)
 
     @property
+    def PDF_ROTATION_DOMINANT_ANGLE_THRESHOLD(self) -> float:
+        """minimum share of characters that must agree on a single 90-degree orientation
+        before a rotated page's rendered image is re-oriented to make text upright
+
+        Only consulted for pages with a non-zero ``/Rotate``. The fraction is intentionally
+        high so that pages without a clear dominant text direction are left untouched.
+        """
+        return self._get_float("PDF_ROTATION_DOMINANT_ANGLE_THRESHOLD", 0.95)
+
+    @property
     def PDF_RENDER_MAX_PIXELS_PER_PAGE(self) -> int:
         """maximum number of pixels (width * height) a single PDF page may render to
 

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -337,6 +337,9 @@ class PageLayout:
             "width": page.image.width if page.image else None,
             "height": page.image.height if page.image else None,
             "pdf_rotation": int(page.image.info.get("pdf_rotation", 0)) if page.image else 0,
+            "pdf_rotation_correction": (
+                int(page.image.info.get("pdf_rotation_correction", 0)) if page.image else 0
+            ),
         }
         page.image_path = os.path.abspath(image_path) if image_path else None
         page.document_filename = os.path.abspath(document_filename) if document_filename else None

--- a/unstructured_inference/inference/pdf_image.py
+++ b/unstructured_inference/inference/pdf_image.py
@@ -43,6 +43,95 @@ def _get_pdfium_module():
     return pdfium
 
 
+def _iter_ltchars(obj):
+    """Yield every ``LTChar`` reachable from a pdfminer layout object."""
+    from pdfminer.layout import LTChar, LTContainer
+
+    if isinstance(obj, LTChar):
+        yield obj
+    elif isinstance(obj, LTContainer):
+        for child in obj:
+            yield from _iter_ltchars(child)
+
+
+def _dominant_text_rotation(page_layout, threshold: float) -> int:
+    """Estimate the extra rotation (a multiple of 90 degrees) to apply to a rendered page
+    so that its dominant text becomes horizontal.
+
+    The angle is derived from pdfminer character matrices, which are expressed in the
+    page's *display* frame (pdfminer already honors ``/Rotate``) — the same frame the
+    rendered bitmap lives in. This is the only orientation signal that reliably matches
+    the render: pdfium's character-angle APIs report in the unrotated page frame and do
+    not map cleanly to the displayed image.
+
+    Returns ``0`` (no correction) unless a single non-zero 90-degree orientation accounts
+    for at least ``threshold`` of the characters, so pages without a clear dominant text
+    direction are left in their display frame.
+    """
+    counts = {0: 0, 90: 0, 180: 0, 270: 0}
+    total = 0
+    for char in _iter_ltchars(page_layout):
+        angle = math.degrees(math.atan2(char.matrix[1], char.matrix[0])) % 360
+        bucket = min((0, 90, 180, 270, 360), key=lambda k: abs(k - angle)) % 360
+        counts[bucket] += 1
+        total += 1
+
+    if total == 0:
+        return 0
+
+    dominant = max(counts, key=counts.get)
+    if dominant == 0 or counts[dominant] / total < threshold:
+        return 0
+    # PIL's rotate() is counter-clockwise, so the rotation that brings text drawn at
+    # ``dominant`` degrees back to horizontal is its complement.
+    return (360 - dominant) % 360
+
+
+def _as_pdfminer_source(filename, file):
+    """Return a path or a rewound byte stream that pdfminer can read without disturbing
+    the caller's ``file`` object."""
+    import io
+
+    if filename is not None:
+        return filename
+    if isinstance(file, (bytes, bytearray)):
+        return io.BytesIO(bytes(file))
+    # file-like: snapshot its bytes so we don't consume the caller's stream position
+    position = file.tell()
+    file.seek(0)
+    data = file.read()
+    file.seek(position)
+    return io.BytesIO(data)
+
+
+def _estimate_rotation_corrections(
+    filename,
+    file,
+    rotated_page_indices: list,
+    password: Optional[str],
+    threshold: float,
+) -> dict:
+    """Map each rotated page index (0-based) to the extra rotation that makes its dominant
+    text horizontal. Returns ``{}`` on any failure so rendering degrades gracefully to the
+    page's native display frame (still consistent with pdfminer, just possibly sideways)."""
+    if not rotated_page_indices:
+        return {}
+    try:
+        from pdfminer.high_level import extract_pages
+
+        wanted = sorted(rotated_page_indices)
+        source = _as_pdfminer_source(filename, file)
+        corrections = {}
+        for idx, page_layout in zip(
+            wanted,
+            extract_pages(source, page_numbers=wanted, password=password or ""),
+        ):
+            corrections[idx] = _dominant_text_rotation(page_layout, threshold)
+        return corrections
+    except Exception:
+        return {}
+
+
 def convert_pdf_to_image(
     filename: Optional[str] = None,
     file: Optional[Union[bytes, BinaryIO]] = None,
@@ -72,9 +161,35 @@ def convert_pdf_to_image(
         pdf_render_max_pixels_per_page = inference_config.PDF_RENDER_MAX_PIXELS_PER_PAGE
     pdfium = _get_pdfium_module()
 
+    def _in_range(page_num: int) -> bool:
+        return (first_page is None or page_num >= first_page) and (
+            last_page is None or page_num <= last_page
+        )
+
     with _pdfium_lock:
         pdf = pdfium.PdfDocument(filename or file, password=password)
         n_pages = len(pdf)
+
+        # Pre-scan page rotations so the (heavier) text-orientation pass only runs on the
+        # pages the author explicitly marked as rotated (Guard 1: /Rotate != 0).
+        page_rotations: dict[int, int] = {}
+        for i in range(n_pages):
+            if not _in_range(i + 1):
+                continue
+            pg = pdf[i]
+            try:
+                page_rotations[i] = pg.get_rotation()
+            finally:
+                pg.close()
+
+    rotated_page_indices = [i for i, rot in page_rotations.items() if rot]
+    rotation_corrections = _estimate_rotation_corrections(
+        filename,
+        file,
+        rotated_page_indices,
+        password,
+        inference_config.PDF_ROTATION_DOMINANT_ANGLE_THRESHOLD,
+    )
 
     try:
         images: dict[int, Image.Image] = {}
@@ -107,10 +222,17 @@ def convert_pdf_to_image(
                     finally:
                         bitmap.close()
 
+                    # pypdfium2 already renders with /Rotate applied (the display frame),
+                    # which matches pdfminer's coordinate frame. Only apply an *additional*
+                    # text-orientation correction when one was estimated, and apply the
+                    # same angle to the pdfminer coordinates downstream (via the stored
+                    # metadata) so the two layers stay consistent.
                     rotation = page.get_rotation()
-                    if rotation:
-                        pil_image = pil_image.rotate(rotation, expand=True)
+                    correction = rotation_corrections.get(i, 0)
+                    if correction:
+                        pil_image = pil_image.rotate(correction, expand=True)
                     pil_image.info["pdf_rotation"] = rotation
+                    pil_image.info["pdf_rotation_correction"] = correction
 
                 finally:
                     page.close()
@@ -120,6 +242,7 @@ def convert_pdf_to_image(
 
                 png_meta = PngInfo()
                 png_meta.add_text("pdf_rotation", str(rotation))
+                png_meta.add_text("pdf_rotation_correction", str(correction))
                 pil_image.save(
                     fn,
                     format="PNG",

--- a/unstructured_inference/inference/pdf_image.py
+++ b/unstructured_inference/inference/pdf_image.py
@@ -7,6 +7,8 @@ from pathlib import Path, PurePath
 from threading import Lock
 from typing import BinaryIO, Optional, Union
 
+from pdfminer.high_level import extract_pages
+from pdfminer.layout import LTChar, LTContainer
 from PIL import Image
 from PIL.PngImagePlugin import PngInfo
 
@@ -45,8 +47,6 @@ def _get_pdfium_module():
 
 def _iter_ltchars(obj):
     """Yield every ``LTChar`` reachable from a pdfminer layout object."""
-    from pdfminer.layout import LTChar, LTContainer
-
     if isinstance(obj, LTChar):
         yield obj
     elif isinstance(obj, LTContainer):
@@ -117,8 +117,6 @@ def _estimate_rotation_corrections(
     if not rotated_page_indices:
         return {}
     try:
-        from pdfminer.high_level import extract_pages
-
         wanted = sorted(rotated_page_indices)
         source = _as_pdfminer_source(filename, file)
         corrections = {}

--- a/uv.lock
+++ b/uv.lock
@@ -482,32 +482,44 @@ name = "cryptography"
 version = "46.0.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "platform_machine != 's390x' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/47/93/ac8f3d5ff04d54bc814e961a43ae5b0b146154c89c61b47bb07557679b18/cryptography-46.0.7.tar.gz", hash = "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5", size = 750652, upload-time = "2026-04-08T01:57:54.692Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/5d/4a8f770695d73be252331e60e526291e3df0c9b27556a90a6b47bccca4c2/cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:ea42cbe97209df307fdc3b155f1b6fa2577c0defa8f1f7d3be7d31d189108ad4", size = 7179869, upload-time = "2026-04-08T01:56:17.157Z" },
     { url = "https://files.pythonhosted.org/packages/5f/45/6d80dc379b0bbc1f9d1e429f42e4cb9e1d319c7a8201beffd967c516ea01/cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325", size = 4275492, upload-time = "2026-04-08T01:56:19.36Z" },
     { url = "https://files.pythonhosted.org/packages/4a/9a/1765afe9f572e239c3469f2cb429f3ba7b31878c893b246b4b2994ffe2fe/cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308", size = 4426670, upload-time = "2026-04-08T01:56:21.415Z" },
     { url = "https://files.pythonhosted.org/packages/8f/3e/af9246aaf23cd4ee060699adab1e47ced3f5f7e7a8ffdd339f817b446462/cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77", size = 4280275, upload-time = "2026-04-08T01:56:23.539Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/54/6bbbfc5efe86f9d71041827b793c24811a017c6ac0fd12883e4caa86b8ed/cryptography-46.0.7-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1", size = 4928402, upload-time = "2026-04-08T01:56:25.624Z" },
     { url = "https://files.pythonhosted.org/packages/2d/cf/054b9d8220f81509939599c8bdbc0c408dbd2bdd41688616a20731371fe0/cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef", size = 4459985, upload-time = "2026-04-08T01:56:27.309Z" },
     { url = "https://files.pythonhosted.org/packages/f9/46/4e4e9c6040fb01c7467d47217d2f882daddeb8828f7df800cb806d8a2288/cryptography-46.0.7-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de", size = 3990652, upload-time = "2026-04-08T01:56:29.095Z" },
     { url = "https://files.pythonhosted.org/packages/36/5f/313586c3be5a2fbe87e4c9a254207b860155a8e1f3cca99f9910008e7d08/cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83", size = 4279805, upload-time = "2026-04-08T01:56:30.928Z" },
+    { url = "https://files.pythonhosted.org/packages/69/33/60dfc4595f334a2082749673386a4d05e4f0cf4df8248e63b2c3437585f2/cryptography-46.0.7-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb", size = 4892883, upload-time = "2026-04-08T01:56:32.614Z" },
     { url = "https://files.pythonhosted.org/packages/c7/0b/333ddab4270c4f5b972f980adef4faa66951a4aaf646ca067af597f15563/cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b", size = 4459756, upload-time = "2026-04-08T01:56:34.306Z" },
     { url = "https://files.pythonhosted.org/packages/d2/14/633913398b43b75f1234834170947957c6b623d1701ffc7a9600da907e89/cryptography-46.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85", size = 4410244, upload-time = "2026-04-08T01:56:35.977Z" },
     { url = "https://files.pythonhosted.org/packages/10/f2/19ceb3b3dc14009373432af0c13f46aa08e3ce334ec6eff13492e1812ccd/cryptography-46.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e", size = 4674868, upload-time = "2026-04-08T01:56:38.034Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/bb/a5c213c19ee94b15dfccc48f363738633a493812687f5567addbcbba9f6f/cryptography-46.0.7-cp311-abi3-win32.whl", hash = "sha256:d23c8ca48e44ee015cd0a54aeccdf9f09004eba9fc96f38c911011d9ff1bd457", size = 3026504, upload-time = "2026-04-08T01:56:39.666Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/02/7788f9fefa1d060ca68717c3901ae7fffa21ee087a90b7f23c7a603c32ae/cryptography-46.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:397655da831414d165029da9bc483bed2fe0e75dde6a1523ec2fe63f3c46046b", size = 3488363, upload-time = "2026-04-08T01:56:41.893Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/7f/cd42fc3614386bc0c12f0cb3c4ae1fc2bbca5c9662dfed031514911d513d/cryptography-46.0.7-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:462ad5cb1c148a22b2e3bcc5ad52504dff325d17daf5df8d88c17dda1f75f2a4", size = 7165618, upload-time = "2026-04-08T01:57:10.645Z" },
     { url = "https://files.pythonhosted.org/packages/a5/d0/36a49f0262d2319139d2829f773f1b97ef8aef7f97e6e5bd21455e5a8fb5/cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7", size = 4270628, upload-time = "2026-04-08T01:57:12.885Z" },
     { url = "https://files.pythonhosted.org/packages/8a/6c/1a42450f464dda6ffbe578a911f773e54dd48c10f9895a23a7e88b3e7db5/cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832", size = 4415405, upload-time = "2026-04-08T01:57:14.923Z" },
     { url = "https://files.pythonhosted.org/packages/9a/92/4ed714dbe93a066dc1f4b4581a464d2d7dbec9046f7c8b7016f5286329e2/cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163", size = 4272715, upload-time = "2026-04-08T01:57:16.638Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e6/a26b84096eddd51494bba19111f8fffe976f6a09f132706f8f1bf03f51f7/cryptography-46.0.7-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2", size = 4918400, upload-time = "2026-04-08T01:57:19.021Z" },
     { url = "https://files.pythonhosted.org/packages/c7/08/ffd537b605568a148543ac3c2b239708ae0bd635064bab41359252ef88ed/cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067", size = 4450634, upload-time = "2026-04-08T01:57:21.185Z" },
     { url = "https://files.pythonhosted.org/packages/16/01/0cd51dd86ab5b9befe0d031e276510491976c3a80e9f6e31810cce46c4ad/cryptography-46.0.7-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0", size = 3985233, upload-time = "2026-04-08T01:57:22.862Z" },
     { url = "https://files.pythonhosted.org/packages/92/49/819d6ed3a7d9349c2939f81b500a738cb733ab62fbecdbc1e38e83d45e12/cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba", size = 4271955, upload-time = "2026-04-08T01:57:24.814Z" },
+    { url = "https://files.pythonhosted.org/packages/80/07/ad9b3c56ebb95ed2473d46df0847357e01583f4c52a85754d1a55e29e4d0/cryptography-46.0.7-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006", size = 4879888, upload-time = "2026-04-08T01:57:26.88Z" },
     { url = "https://files.pythonhosted.org/packages/b8/c7/201d3d58f30c4c2bdbe9b03844c291feb77c20511cc3586daf7edc12a47b/cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0", size = 4449961, upload-time = "2026-04-08T01:57:29.068Z" },
     { url = "https://files.pythonhosted.org/packages/a5/ef/649750cbf96f3033c3c976e112265c33906f8e462291a33d77f90356548c/cryptography-46.0.7-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85", size = 4401696, upload-time = "2026-04-08T01:57:31.029Z" },
     { url = "https://files.pythonhosted.org/packages/41/52/a8908dcb1a389a459a29008c29966c1d552588d4ae6d43f3a1a4512e0ebe/cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e", size = 4664256, upload-time = "2026-04-08T01:57:33.144Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/fa/f0ab06238e899cc3fb332623f337a7364f36f4bb3f2534c2bb95a35b132c/cryptography-46.0.7-cp38-abi3-win32.whl", hash = "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246", size = 3013001, upload-time = "2026-04-08T01:57:34.933Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/f1/00ce3bde3ca542d1acd8f8cfa38e446840945aa6363f9b74746394b14127/cryptography-46.0.7-cp38-abi3-win_amd64.whl", hash = "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3", size = 3472985, upload-time = "2026-04-08T01:57:36.714Z" },
+    { url = "https://files.pythonhosted.org/packages/63/0c/dca8abb64e7ca4f6b2978769f6fea5ad06686a190cec381f0a796fdcaaba/cryptography-46.0.7-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fc9ab8856ae6cf7c9358430e49b368f3108f050031442eaeb6b9d87e4dcf4e4f", size = 3476879, upload-time = "2026-04-08T01:57:38.664Z" },
     { url = "https://files.pythonhosted.org/packages/3a/ea/075aac6a84b7c271578d81a2f9968acb6e273002408729f2ddff517fed4a/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:d3b99c535a9de0adced13d159c5a9cf65c325601aa30f4be08afd680643e9c15", size = 4219700, upload-time = "2026-04-08T01:57:40.625Z" },
     { url = "https://files.pythonhosted.org/packages/6c/7b/1c55db7242b5e5612b29fc7a630e91ee7a6e3c8e7bf5406d22e206875fbd/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:d02c738dacda7dc2a74d1b2b3177042009d5cab7c7079db74afc19e56ca1b455", size = 4385982, upload-time = "2026-04-08T01:57:42.725Z" },
     { url = "https://files.pythonhosted.org/packages/cb/da/9870eec4b69c63ef5925bf7d8342b7e13bc2ee3d47791461c4e49ca212f4/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:04959522f938493042d595a736e7dbdff6eb6cc2339c11465b3ff89343b65f65", size = 4219115, upload-time = "2026-04-08T01:57:44.939Z" },
     { url = "https://files.pythonhosted.org/packages/f4/72/05aa5832b82dd341969e9a734d1812a6aadb088d9eb6f0430fc337cc5a8f/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:3986ac1dee6def53797289999eabe84798ad7817f3e97779b5061a95b0ee4968", size = 4385479, upload-time = "2026-04-08T01:57:46.86Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2a/1b016902351a523aa2bd446b50a5bc1175d7a7d1cf90fe2ef904f9b84ebc/cryptography-46.0.7-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:258514877e15963bd43b558917bc9f54cf7cf866c38aa576ebf47a77ddbc43a4", size = 3412829, upload-time = "2026-04-08T01:57:48.874Z" },
 ]
 
 [[package]]
@@ -2111,6 +2123,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pdfminer-six"
+version = "20260107"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "charset-normalizer" },
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/34/a4/5cec1112009f0439a5ca6afa8ace321f0ab2f48da3255b7a1c8953014670/pdfminer_six-20260107.tar.gz", hash = "sha256:96bfd431e3577a55a0efd25676968ca4ce8fd5b53f14565f85716ff363889602", size = 8512094, upload-time = "2026-01-07T13:29:12.937Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/8b/28c4eaec9d6b036a52cb44720408f26b1a143ca9bce76cc19e8f5de00ab4/pdfminer_six-20260107-py3-none-any.whl", hash = "sha256:366585ba97e80dffa8f00cebe303d2f381884d8637af4ce422f1df3ef38111a9", size = 6592252, upload-time = "2026-01-07T13:29:10.742Z" },
+]
+
+[[package]]
 name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3329,6 +3354,7 @@ dependencies = [
     { name = "onnxruntime" },
     { name = "opencv-python" },
     { name = "pandas" },
+    { name = "pdfminer-six" },
     { name = "pypdfium2" },
     { name = "rapidfuzz" },
     { name = "scipy" },
@@ -3369,6 +3395,7 @@ requires-dist = [
     { name = "onnxruntime", specifier = ">=1.25.0" },
     { name = "opencv-python", specifier = ">=4.13.0.90" },
     { name = "pandas", specifier = ">=1.5.0" },
+    { name = "pdfminer-six", specifier = ">=20231228" },
     { name = "pypdfium2", specifier = ">=5.0.0" },
     { name = "rapidfuzz", specifier = ">=3.14.3" },
     { name = "scipy", specifier = ">=1.17.0" },


### PR DESCRIPTION
## Problem

For PDF pages with a non-zero `/Rotate`, the rendered page image and pdfminer's extracted text ended up in different coordinate frames. `convert_pdf_to_image` re-applied the page `/Rotate` with PIL on top of pypdfium2's render — but pypdfium2 already renders the display frame, so the extra rotation effectively returned the image to the un-rotated MediaBox frame. pdfminer, meanwhile, honors `/Rotate` and reports coordinates in the display frame. The two were then off by the page rotation, which scrambled the merged layout downstream.

## Fix

- `convert_pdf_to_image` no longer re-applies `/Rotate` on top of pypdfium2's render. The rendered image now shares pdfminer's display frame by default.
- For `/Rotate != 0` pages, the dominant text orientation is estimated from pdfminer character matrices (the only signal that reliably matches the rendered image). When a single 90-degree orientation clearly dominates — controlled by the new `PDF_ROTATION_DOMINANT_ANGLE_THRESHOLD` (default `0.95`) — the rendered image is rotated so its text is upright.
- The applied correction is exposed as `pdf_rotation_correction` in the page image metadata (PIL `.info` and PNG text), so downstream consumers can rotate extracted coordinates by the same angle and stay aligned.
- Orientation estimation failures degrade gracefully to no correction (image stays in its native display frame — still consistent with pdfminer, just possibly not upright).

### Guards
1. Only pages with a non-zero `/Rotate` are considered for correction.
2. A correction is applied only when one 90-degree orientation accounts for at least the threshold share of characters; ambiguous pages are left untouched.

The correction is applied to the image and reported for the coordinates together, so it can only affect uprightness, never the consistency between the layers.

## Tests
- Existing rotation test still passes (now via the correct render-then-correct mechanism).
- Added coverage for the no-correction path on unrotated pages and for the threshold guard skipping correction below the configured share.

Paired with the corresponding change in `unstructured` that mirrors `pdf_rotation_correction` onto the extracted coordinates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix rotated PDF rendering by removing duplicate rotation and applying a text-based correction. Images and extracted coordinates now align with `pdfminer`, pages become upright when a clear orientation is detected, and `pdfminer.six` is now declared so the correction always runs.

- **Bug Fixes**
  - Stop re-applying page `/Rotate` in `convert_pdf_to_image`; `pypdfium2` already renders the display frame matching `pdfminer` coordinates.
  - For `/Rotate != 0` pages, estimate the dominant 90° text direction from `pdfminer` characters and rotate only if it meets `PDF_ROTATION_DOMINANT_ANGLE_THRESHOLD` (default 0.95); ambiguous pages are left as-is.
  - Store the applied angle as `pdf_rotation_correction` in PNG/PIL info and surface it in layout metadata so downstream consumers can rotate coordinates to match.

- **Dependencies**
  - Add `pdfminer.six` (>=20231228) and move imports to module level to fail fast if missing; refresh lockfile.

<sup>Written for commit b6c6c46c5b699810257cec02e1dd5fe29672ca82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-inference/pull/514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

