### PR TITLE
Normalize list-returning detection models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.6.14
+
+### Fixes
+- **Normalize object-detection model results**: the object-detection boundary now converts legacy list results to `LayoutElements`, so page-layout routing works consistently across built-in detection models.
+
 ## 1.6.13
 
 ### Fixes

--- a/test_unstructured_inference/inference/test_layout.py
+++ b/test_unstructured_inference/inference/test_layout.py
@@ -122,6 +122,42 @@ def test_get_page_elements(monkeypatch, mock_final_layout):
     assert elements == page.elements_array
 
 
+class ListPredictingDetectionModel(UnstructuredObjectDetectionModel):
+    def __init__(self, predictions):
+        super().__init__()
+        self.predictions = predictions
+
+    def initialize(self, *args, **kwargs):
+        pass
+
+    def predict(self, x):
+        return self.predictions
+
+
+@pytest.mark.parametrize(
+    ("predictions", "expected_texts"),
+    [
+        ([layoutelement.LayoutElement.from_coords(0, 0, 1, 1, text="detected")], ["detected"]),
+        ([], []),
+    ],
+)
+def test_get_page_elements_with_detection_model_returning_a_list(
+    mock_image,
+    predictions,
+    expected_texts,
+):
+    page = layout.PageLayout(
+        number=1,
+        image=mock_image,
+        detection_model=ListPredictingDetectionModel(predictions),
+    )
+
+    result = page.get_elements_with_detection_model(inplace=False)
+
+    assert isinstance(result, layoutelement.LayoutElements)
+    assert [element.text for element in result.as_list()] == expected_texts
+
+
 class MockPool:
     def map(self, f, xs):
         return [f(x) for x in xs]

--- a/test_unstructured_inference/inference/test_layout.py
+++ b/test_unstructured_inference/inference/test_layout.py
@@ -155,7 +155,7 @@ def test_get_page_elements_with_detection_model_returning_a_list(
     result = page.get_elements_with_detection_model(inplace=False)
 
     assert isinstance(result, layoutelement.LayoutElements)
-    assert [element.text for element in result.as_list()] == expected_texts
+    assert result.texts.tolist() == expected_texts
 
 
 class MockPool:

--- a/test_unstructured_inference/models/test_detectron2onnx.py
+++ b/test_unstructured_inference/models/test_detectron2onnx.py
@@ -6,6 +6,7 @@ from PIL import Image
 
 import unstructured_inference.models.base as models
 import unstructured_inference.models.detectron2onnx as detectron2
+from unstructured_inference.inference.layoutelement import LayoutElements
 
 
 class MockDetectron2ONNXLayoutModel:
@@ -50,7 +51,7 @@ def test_unstructured_detectron_model():
     model.model = 1
     with patch.object(detectron2.UnstructuredDetectronONNXModel, "predict", return_value=[]):
         result = model(None)
-    assert isinstance(result, list)
+    assert isinstance(result, LayoutElements)
     assert len(result) == 0
 
 
@@ -67,8 +68,9 @@ def test_inference():
             image = Image.open(fp)
             image.load()
         elements = model(image)
+        assert isinstance(elements, LayoutElements)
         assert len(elements) == 1
-        element = elements[0]
+        element = elements.as_list()[0]
         (x1, y1), _, (x2, y2), _ = element.bbox.coordinates
         assert hasattr(
             element,

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.6.13"  # pragma: no cover
+__version__ = "1.6.14"  # pragma: no cover

--- a/unstructured_inference/models/unstructuredmodel.py
+++ b/unstructured_inference/models/unstructuredmodel.py
@@ -61,7 +61,10 @@ class UnstructuredObjectDetectionModel(UnstructuredModel):
 
     def __call__(self, x: Image) -> LayoutElements:
         """Inference using function call interface."""
-        return super().__call__(x)
+        predictions = super().__call__(x)
+        if isinstance(predictions, LayoutElements):
+            return predictions
+        return LayoutElements.from_list(predictions)
 
     @staticmethod
     def enhance_regions(


### PR DESCRIPTION
## Summary

- normalize legacy list results from object-detection models into `LayoutElements`
- perform normalization at the shared model boundary
- update Detectron coverage and add a page-layout regression test

## Why

Some built-in detection models return a list while page layout code expects `LayoutElements` and reads attributes such as `routing`. That mismatch can raise `AttributeError` in a normal inference route.

## Compatibility note

The shared object-detection call now consistently returns `LayoutElements`. Out-of-tree callers that directly consumed a raw list should use `.as_list()` when they need the prior shape. The draft status leaves room to confirm that boundary contract.

## Validation

- `uv run --locked --no-sync pytest -q test_unstructured_inference/inference/test_layout.py test_unstructured_inference/models/test_detectron2onnx.py` — 59 passed
- Ruff check and format check passed for all changed Python files
- changelog and package versions both set to 1.6.14


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-inference/pull/516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

