### PR TITLE
Reject fixed-layout page-count mismatches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.6.14
+
+### Fixes
+- **Reject fixed-layout page-count mismatches**: fixed layouts supplied to `DocumentLayout.from_file` must now match the PDF page count, avoiding silent truncation when the two sequences differ.
+
 ## 1.6.13
 
 ### Fixes

--- a/test_unstructured_inference/inference/test_layout.py
+++ b/test_unstructured_inference/inference/test_layout.py
@@ -317,13 +317,20 @@ def test_from_file(monkeypatch, mock_final_layout):
             assert page.image is None
 
 
-@pytest.mark.parametrize("fixed_layouts", [[[]], [[], [], []]])
-def test_from_file_rejects_fixed_layout_count_mismatch(monkeypatch, fixed_layouts):
-    monkeypatch.setattr(layout, "convert_pdf_to_image", lambda **kwargs: ["a.png", "b.png"])
+@pytest.mark.parametrize(
+    ("page_images", "fixed_layouts"),
+    [
+        (["a.png", "b.png"], [[]]),
+        (["a.png", "b.png"], [[], [], []]),
+        (["a.png"], [[], []]),
+    ],
+)
+def test_from_file_rejects_fixed_layout_count_mismatch(monkeypatch, page_images, fixed_layouts):
+    monkeypatch.setattr(layout, "convert_pdf_to_image", lambda **kwargs: page_images)
 
     with pytest.raises(
         ValueError,
-        match=f"received {len(fixed_layouts)} entries; PDF has 2 pages",
+        match=f"entry count is {len(fixed_layouts)}, page count is {len(page_images)}",
     ):
         layout.DocumentLayout.from_file("fake-file.pdf", fixed_layouts=fixed_layouts)
 

--- a/test_unstructured_inference/inference/test_layout.py
+++ b/test_unstructured_inference/inference/test_layout.py
@@ -323,7 +323,7 @@ def test_from_file_rejects_fixed_layout_count_mismatch(monkeypatch, fixed_layout
 
     with pytest.raises(
         ValueError,
-        match=rf"received {len(fixed_layouts)} entries for 2 pages",
+        match=f"received {len(fixed_layouts)} entries; PDF has 2 pages",
     ):
         layout.DocumentLayout.from_file("fake-file.pdf", fixed_layouts=fixed_layouts)
 

--- a/test_unstructured_inference/inference/test_layout.py
+++ b/test_unstructured_inference/inference/test_layout.py
@@ -317,6 +317,17 @@ def test_from_file(monkeypatch, mock_final_layout):
             assert page.image is None
 
 
+@pytest.mark.parametrize("fixed_layouts", [[[]], [[], [], []]])
+def test_from_file_rejects_fixed_layout_count_mismatch(monkeypatch, fixed_layouts):
+    monkeypatch.setattr(layout, "convert_pdf_to_image", lambda **kwargs: ["a.png", "b.png"])
+
+    with pytest.raises(
+        ValueError,
+        match=rf"received {len(fixed_layouts)} entries for 2 pages",
+    ):
+        layout.DocumentLayout.from_file("fake-file.pdf", fixed_layouts=fixed_layouts)
+
+
 def test_from_file_rotated_pdf_stores_rotation_in_metadata(monkeypatch, mock_final_layout):
     """image_metadata includes pdf_rotation for rotated PDF pages."""
 

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.6.13"  # pragma: no cover
+__version__ = "1.6.14"  # pragma: no cover

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -79,7 +79,7 @@ class DocumentLayout:
             elif len(fixed_layouts) != number_of_pages:
                 raise ValueError(
                     "fixed_layouts must contain one entry per PDF page: "
-                    f"received {len(fixed_layouts)} entries for {number_of_pages} pages",
+                    f"received {len(fixed_layouts)} entries; PDF has {number_of_pages} pages",
                 )
             for i, (image_path, fixed_layout) in enumerate(zip(image_paths, fixed_layouts)):
                 # NOTE(robinson) - In the future, maybe we detect the page number and default

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -76,6 +76,11 @@ class DocumentLayout:
             pages: List[PageLayout] = []
             if fixed_layouts is None:
                 fixed_layouts = [None for _ in range(0, number_of_pages)]
+            elif len(fixed_layouts) != number_of_pages:
+                raise ValueError(
+                    "fixed_layouts must contain one entry per PDF page: "
+                    f"received {len(fixed_layouts)} entries for {number_of_pages} pages",
+                )
             for i, (image_path, fixed_layout) in enumerate(zip(image_paths, fixed_layouts)):
                 # NOTE(robinson) - In the future, maybe we detect the page number and default
                 # to the index if it is not detected

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -79,7 +79,7 @@ class DocumentLayout:
             elif len(fixed_layouts) != number_of_pages:
                 raise ValueError(
                     "fixed_layouts must contain one entry per PDF page: "
-                    f"received {len(fixed_layouts)} entries; PDF has {number_of_pages} pages",
+                    f"entry count is {len(fixed_layouts)}, page count is {number_of_pages}",
                 )
             for i, (image_path, fixed_layout) in enumerate(zip(image_paths, fixed_layouts)):
                 # NOTE(robinson) - In the future, maybe we detect the page number and default


### PR DESCRIPTION
## Summary

- require fixed-layout input count to match the PDF page count
- raise a clear `ValueError` before page construction when the counts differ
- cover both too-few and too-many layouts

## Why

The page construction path used `zip()`, which silently stopped at the shorter input. Too few fixed layouts therefore produced a successful result with missing PDF pages.

## Compatibility note

This intentionally tightens validation: callers that previously supplied extra fixed layouts (which were ignored) will now receive an error. The draft status leaves room to confirm that contract before merging.

## Validation

- `uv run --locked --no-sync pytest -q test_unstructured_inference/inference/test_layout.py` — 54 passed
- Ruff check and format check passed for all changed Python files
- changelog and package versions both set to 1.6.14


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-inference/pull/517?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

