### PR TITLE
fix(layout): bound model input copy memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.6.14
+
+### Fixes
+- **Bound model input copy memory**: `process_data_with_model` now copies inputs into its temporary file in 1 MiB chunks instead of reading the complete input into one `bytes` allocation.
+
 ## 1.6.13
 
 ### Fixes

--- a/test_unstructured_inference/inference/test_layout.py
+++ b/test_unstructured_inference/inference/test_layout.py
@@ -1,6 +1,7 @@
 import os
 import os.path
 import tempfile
+from io import BytesIO
 from unittest.mock import MagicMock, mock_open, patch
 
 import numpy as np
@@ -157,6 +158,43 @@ def test_process_data_with_model(monkeypatch, mock_final_layout, model_name):
         open("") as fp,
     ):
         assert layout.process_data_with_model(fp, model_name=model_name)
+
+
+def test_process_data_with_model_copies_input_in_bounded_chunks(monkeypatch):
+    class RecordingBytesIO(BytesIO):
+        def __init__(self, value: bytes):
+            super().__init__(value)
+            self.read_sizes: list[int] = []
+
+        def read(self, size: int = -1) -> bytes:
+            self.read_sizes.append(size)
+            return super().read(size)
+
+    data = b"sample content" * 200_000
+    source = RecordingBytesIO(data)
+    expected_layout = layout.DocumentLayout.from_pages([])
+
+    def fake_process_file_with_model(filename, model_name, password=None, **kwargs):
+        with open(filename, "rb") as copied_file:
+            assert copied_file.read() == data
+        assert model_name == "test-model"
+        assert password == "test-password"
+        assert kwargs == {"is_image": True}
+        return expected_layout
+
+    monkeypatch.setattr(layout, "process_file_with_model", fake_process_file_with_model)
+
+    result = layout.process_data_with_model(
+        source,
+        model_name="test-model",
+        password="test-password",
+        is_image=True,
+    )
+
+    assert result is expected_layout
+    assert source.read_sizes
+    assert -1 not in source.read_sizes
+    assert max(source.read_sizes) == layout._FILE_COPY_CHUNK_SIZE
 
 
 def test_process_data_with_model_raises_on_invalid_model_name():

--- a/unstructured_inference/__version__.py
+++ b/unstructured_inference/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.6.13"  # pragma: no cover
+__version__ = "1.6.14"  # pragma: no cover

--- a/unstructured_inference/inference/layout.py
+++ b/unstructured_inference/inference/layout.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import tempfile
 from functools import cached_property
 from pathlib import PurePath
@@ -24,6 +25,8 @@ from unstructured_inference.visualize import draw_bbox
 
 convert_pdf_to_image = pdf_image_utils.convert_pdf_to_image
 _pdfium_lock = pdf_image_utils._pdfium_lock
+
+_FILE_COPY_CHUNK_SIZE = 1024 * 1024
 
 
 class DocumentLayout:
@@ -366,7 +369,7 @@ def process_data_with_model(
     with tempfile.TemporaryDirectory() as tmp_dir_path:
         file_path = os.path.join(tmp_dir_path, "document")
         with open(file_path, "wb") as f:
-            f.write(data.read())
+            shutil.copyfileobj(data, f, length=_FILE_COPY_CHUNK_SIZE)
             f.flush()
         layout = process_file_with_model(
             file_path,


### PR DESCRIPTION
## Summary

- Copy model inputs into their temporary file in 1 MiB chunks.
- Avoid reading the complete input into a single `bytes` allocation.
- Add regression coverage verifying that the source is never read without a size bound.

## Why

`process_data_with_model` currently calls `data.read()` before writing the temporary file. This creates an additional allocation proportional to the complete input size and can increase peak memory substantially for large documents.

Chunked copying bounds the temporary copy buffer without changing the resulting file, API behavior, or supported file sizes.

## Impact

In a representative end-to-end partition API benchmark using a 70.4 MB two-page PDF:

- Request-attributable process RSS decreased by 67.2 MiB.
- Request-attributable container memory decreased by 67.3 MiB.
- Median latency changed from 16.774s to 18.070s (+7.7%).

The memory reduction is approximately proportional to input size. The current 1 MiB chunk size introduces a measurable throughput tradeoff and may benefit from tuning before merge.

## Validation

- `uv run pytest test_unstructured_inference/inference/test_layout.py::test_process_data_with_model_copies_input_in_bounded_chunks -q` — 1 passed.
- `uv run ruff check unstructured_inference/inference/layout.py test_unstructured_inference/inference/test_layout.py` — passed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-inference/pull/518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

